### PR TITLE
feat(workitem): add wi comment command (Story 2-7)

### DIFF
--- a/_bmad-output/implementation-artifacts/2-7-wi-comment.md
+++ b/_bmad-output/implementation-artifacts/2-7-wi-comment.md
@@ -1,6 +1,6 @@
 # Story 2.7：wi comment 命令
 
-Status: review
+Status: done
 
 ## Story
 
@@ -96,3 +96,12 @@ claude-sonnet-4-6
 - `src/commands/workitem.js`（已有：wi comment 命令 line 229-242）
 - `_bmad-output/implementation-artifacts/2-7-wi-comment.md`（本文件，新建）
 - `_bmad-output/implementation-artifacts/sprint-status.yaml`（状态更新）
+
+### Review Findings
+
+- [x] [Review][Patch] 正则 `/^[A-Z]+-\d+$/i` 中 `[A-Z]` 与 `/i` flag 冗余 [src/commands/workitem.js:235] — 已修复为 `/^[A-Za-z]+-\d+$/`
+- [x] [Review][Defer] `process.exit(1)` 在 `withErrorHandling` 内绕过 wrapper [src/commands/workitem.js:237] — deferred, pre-existing 同文件其他命令使用相同模式
+- [x] [Review][Defer] `result?.id ?? resolvedId` 兜底时 `id` 与 `workitemId` 相同 [src/commands/workitem.js:241] — deferred, pre-existing spec 允许"评论 ID 或工作项 ID"，行为符合 AC
+- [x] [Review][Defer] `resolveWorkitemId` 仅搜索前 50 条记录 [src/api.js] — deferred, pre-existing 分页限制非本 diff 引入
+- [x] [Review][Defer] `content` 参数无空字符串/空白校验 [src/commands/workitem.js:243] — deferred, pre-existing 非 AC 要求，同其他命令参数处理一致
+- [x] [Review][Defer] `wi comment` 命令无自动化测试覆盖 — deferred, pre-existing 非 AC 要求，命令层测试覆盖在 Story 7-4 统一处理

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -16,3 +16,11 @@
 - Both `errorMessage` and `statusText` being falsy/empty not tested — edge case produces `{"error":"","code":"API_ERROR"}`.
 - AUTH_MISSING tested via direct `AppError` throw, not through `buildProgram`+`parseAsync` dispatch. Real guard is in `src/index.js` `authRequiredAction`.
 - `workitem.js` has internal `process.exit` calls (INVALID_ARGS guard) that would throw `MockExit` and surface as spurious `API_ERROR` through `withErrorHandling` else branch.
+
+## Deferred from: code review of 2-7-wi-comment (2026-04-02)
+
+- `process.exit(1)` 在 `withErrorHandling` 内绕过 wrapper — 同文件其他命令使用相同模式，建议统一重构为抛出错误让 wrapper 处理
+- `result?.id ?? resolvedId` 兜底时 `id` 与 `workitemId` 相同 — spec 允许工作项 ID 作为兜底，但机器调用方无法区分，后续可考虑增加 `idType` 字段
+- `resolveWorkitemId` 仅搜索前 50 条记录 — 大型项目中序列号超出首页时会误报 NOT_FOUND，建议后续增加分页循环
+- `content` 参数无空字符串/空白校验 — 非 AC 要求，API 可能拒绝空评论，后续可加 guard
+- `wi comment` 命令无自动化测试覆盖 — 命令层测试在 Story 7-4 统一覆盖

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-03-31
-last_updated: 2026-04-02  # story 8-2 done
+last_updated: 2026-04-02  # story 2-7 done
 project: yunxiao-cli
 project_key: NOKEY
 tracking_system: file-system
@@ -61,7 +61,7 @@ development_status:
   2-3-wi-view: done
   2-5-wi-update: backlog
   2-6-wi-delete: done
-  2-7-wi-comment: backlog
+  2-7-wi-comment: done
   2-8-wi-comments: backlog
   epic-2-retrospective: optional
 

--- a/src/commands/workitem.js
+++ b/src/commands/workitem.js
@@ -237,7 +237,7 @@ export function registerWorkitemCommands(program, client, orgId, defaultProjectI
     .option("-p, --project <id>", "Project ID (needed for serial number)")
     .action(withErrorHandling(async (id, content, opts) => {
       const spaceId = opts.project || defaultProjectId;
-      if (/^[A-Z]+-\d+$/i.test(id) && !spaceId) {
+      if (/^[A-Za-z]+-\d+$/.test(id) && !spaceId) {
         printError("INVALID_ARGS", "project ID required for serial number lookup", jsonMode);
         process.exit(1);
       }


### PR DESCRIPTION
## Summary

- 实现 `wi comment <id> <content>` 命令，支持 UUID 和序列号格式（如 `GJBL-1`）
- 通过 `resolveWorkitemId` 解析序列号；调用 `addComment` API 添加评论
- `--json` 模式输出 `{ success, id, workitemId }`；普通模式输出成功确认文字
- 代码审查修复：正则 `/^[A-Z]+-\d+$/i` → `/^[A-Za-z]+-\d+$/`（消除冗余 flag）

## Test plan

- [x] 编译验证通过（`node src/index.js --version`）
- [x] 单元测试 25/25 通过（`npm test`）
- [x] 代码审查完成（1 patch 已修复，5 defer 已记录）
- [ ] 手动验证：`wi comment <uuid> "msg" --json` 返回正确 JSON
- [ ] 手动验证：`wi comment GJBL-1 "msg"`（需 YUNXIAO_PROJECT_ID）成功添加评论
