### PR TITLE
test(7-4): add command-layer tests for wi list --json, AUTH_MISSING, API errors

### DIFF
--- a/_bmad-output/implementation-artifacts/7-4-command-layer-tests.md
+++ b/_bmad-output/implementation-artifacts/7-4-command-layer-tests.md
@@ -1,0 +1,312 @@
+# Story 7.4：命令层测试
+
+Status: done
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a developer,
+I want core command output paths tested for `--json` format and error codes,
+So that the CLI's output contract with AI agents is continuously verified.
+
+## Acceptance Criteria
+
+1. **Given** 执行 `wi list --json`（mock API 返回数据）
+   **When** 运行 `test/commands.test.js`
+   **Then** 测试验证 stdout 是合法 JSON 且包含 `total` 字段
+
+2. **Given** 认证缺失时执行任意命令
+   **When** 测试运行
+   **Then** 验证 stderr 包含 `AUTH_MISSING` 错误码，退出码非零
+
+3. **Given** `--json` 模式下发生 API 错误
+   **When** 测试运行
+   **Then** 验证 stdout 无输出，stderr 包含 `{"error": "...", "code": "API_ERROR"}` 格式
+
+## Tasks / Subtasks
+
+- [x] 创建 `test/commands.test.js` 测试文件 (AC: #1, #2, #3)
+  - [x] 实现 `setupCapture()` helper：mock process.stdout.write / stderr.write / exit，返回捕获数组
+  - [x] 实现 `buildWithErrorHandling(jsonMode)` helper：复制 src/index.js 中的 withErrorHandling 逻辑
+  - [x] 实现 `buildProgram(client, orgId, projectId, jsonMode)` helper：创建 Commander 程序并注册 workitem 命令
+  - [x] AC1：`wi list --json` → stdout 是合法 JSON，包含 `total` 字段和 `items` 数组
+  - [x] AC1 追加：`x-total` header 被正确解析为 total 值
+  - [x] AC2：`withErrorHandling` 捕获 AUTH_MISSING → stderr 含 `AUTH_MISSING` 码，exitCode=1
+  - [x] AC2 追加：stderr 格式为 `{"error":"...","code":"AUTH_MISSING"}`
+  - [x] AC3：API 500 错误 → stdout 为空，stderr 含 `{"error":"...","code":"API_ERROR"}`
+  - [x] AC3 追加：HTTP 404 错误 → stderr 含 `{"error":"...","code":"NOT_FOUND"}`
+  - [x] 追加：`printJson` / `printError` 单元测试（格式契约验证）
+- [x] 运行 `npm test` 确认所有测试通过，无回归 (AC: #1, #2, #3)
+
+## Dev Notes
+
+### 核心挑战：命令层测试策略
+
+命令层测试不同于 API 层测试（7-2/7-3）。命令处理函数是 Commander.js 内部的闭包，无法直接 import 并调用。正确测试方式：
+
+1. **Strategy A（推荐）**：传入 mock client，通过 `registerWorkitemCommands()` 注册命令，然后调用 `program.parseAsync()` 执行
+2. 捕获 `process.stdout.write` / `process.stderr.write` 来验证输出
+3. mock `process.exit` 防止测试进程被终止
+
+### 为什么不能用 Strategy B（api adapter）？
+
+`src/commands/workitem.js` 直接 `import { searchWorkitems, ... } from '../api.js'` —— ESM 模块导出是 sealed/non-configurable，`mock.method()` 无法替换。
+**唯一可行方案**：mock `client.post/get` HTTP 层（Strategy A），让真实 api.js 代码路径执行，通过 mock client 控制返回值。
+
+### `searchWorkitems` 返回结构（api.js 行 87–97）
+
+```js
+// client.post 返回 { data: rawData }
+// rawData 可以是数组或 { data: [...], total: N }
+const items = Array.isArray(rawData) ? rawData : (rawData?.data ?? []);
+const total = parseInt(res.headers?.['x-total'] ?? rawData?.total ?? items.length, 10) || 0;
+return { items, total };
+```
+
+**Mock 方式（测试中使用）：**
+```js
+// 数组格式（简单）：total = items.length
+mock.method(client, 'post', async () => ({ data: [item1, item2] }));
+// → { items: [item1, item2], total: 2 }
+
+// 带 x-total header：total 来自 header
+mock.method(client, 'post', async () => ({ data: [item1], headers: { 'x-total': '100' } }));
+// → { items: [item1], total: 100 }
+```
+
+### `wi list` 命令输出逻辑（workitem.js 行 54–70）
+
+```js
+const { items, total } = await searchWorkitems(client, orgId, spaceId, { ... });
+if (jsonMode) {
+  printJson({ items: items || [], total });  // ← AC1 验证点
+  return;
+}
+```
+
+**重要**：`spaceId = opts.project || defaultProjectId`。测试时必须给 `buildProgram` 传入非空 `projectId`，否则 `INVALID_ARGS` 提前 exit。
+
+### `withErrorHandling` 逻辑（src/index.js 行 28–44）
+
+测试中需复制此函数，不能直接 import（index.js 是 CLI 入口，执行时会加载 config 并发 API 请求）：
+
+```js
+function buildWithErrorHandling(jsonMode) {
+  return (fn) => async (...args) => {
+    try {
+      await fn(...args);
+    } catch (err) {
+      if (err instanceof AppError) {
+        printError(err.code, err.message, jsonMode);
+      } else if (err.response) {
+        const code = err.response.status === 404 ? ERROR_CODE.NOT_FOUND : ERROR_CODE.API_ERROR;
+        printError(code, err.response.data?.errorMessage || err.response.statusText, jsonMode);
+      } else {
+        printError(ERROR_CODE.API_ERROR, err.message, jsonMode);
+      }
+      process.exit(1);
+    }
+  };
+}
+```
+
+### process.exit mock 策略
+
+`withErrorHandling` 在错误时调用 `process.exit(1)`。必须 mock 它，否则测试进程被终止：
+
+```js
+class MockExit extends Error {
+  constructor(code) { super(`process.exit(${code})`); this.exitCode = code; }
+}
+
+// 在 setupCapture() 中：
+mock.method(process, 'exit', (code) => {
+  exitCodes.push(code ?? 0);
+  throw new MockExit(code);
+});
+```
+
+`program.parseAsync` 会将 MockExit 向上抛出 → 在测试中用 `try/catch` 捕获。
+
+### 完整 setupCapture() 实现
+
+```js
+function setupCapture() {
+  const stdout = [];
+  const stderr = [];
+  const exitCodes = [];
+  mock.method(process.stdout, 'write', (data) => { stdout.push(String(data)); return true; });
+  mock.method(process.stderr, 'write', (data) => { stderr.push(String(data)); return true; });
+  mock.method(process, 'exit', (code) => { exitCodes.push(code ?? 0); throw new MockExit(code); });
+  return { stdout, stderr, exitCodes };
+}
+```
+
+### buildProgram() 实现
+
+```js
+import { Command } from 'commander';
+import { registerWorkitemCommands } from '../src/commands/workitem.js';
+import { printError } from '../src/output.js';
+import { AppError, ERROR_CODE } from '../src/errors.js';
+
+function buildProgram(client, orgId, projectId, jsonMode) {
+  const program = new Command();
+  program.exitOverride();  // 防止 Commander 内部调用 process.exit
+  program.configureOutput({ writeErr: () => {} }); // 抑制 Commander 自身错误输出
+  program.option('--json', 'Output as JSON');
+  const withErrorHandling = buildWithErrorHandling(jsonMode);
+  registerWorkitemCommands(program, client, orgId, projectId, withErrorHandling, null, jsonMode);
+  return program;
+}
+```
+
+### API 错误对象格式（与 withErrorHandling 匹配）
+
+```js
+// HTTP 500 错误
+const apiErr = Object.assign(new Error('Internal Server Error'), {
+  response: { status: 500, data: { errorMessage: 'server error' }, statusText: 'Internal Server Error' },
+});
+// HTTP 404 错误
+const notFoundErr = Object.assign(new Error('Not Found'), {
+  response: { status: 404, data: { errorMessage: 'not found' }, statusText: 'Not Found' },
+});
+```
+
+### 完整测试用例骨架
+
+```js
+// test/commands.test.js
+import { test, describe, afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { Command } from 'commander';
+import { registerWorkitemCommands } from '../src/commands/workitem.js';
+import { AppError, ERROR_CODE } from '../src/errors.js';
+import { printJson, printError } from '../src/output.js';
+import { createMockClient, makeWorkitem } from './setup.js';
+
+class MockExit extends Error {
+  constructor(code) { super(`process.exit(${code})`); this.exitCode = code; }
+}
+
+function setupCapture() { ... }
+function buildWithErrorHandling(jsonMode) { ... }
+function buildProgram(client, orgId, projectId, jsonMode) { ... }
+
+describe('命令层：wi list --json', () => {
+  afterEach(() => mock.restoreAll());
+
+  test('stdout 是合法 JSON 且包含 total 字段', async () => {
+    const client = createMockClient();
+    const items = [makeWorkitem({ id: 'wi-001' }), makeWorkitem({ id: 'wi-002' })];
+    mock.method(client, 'post', async () => ({ data: items }));
+    const { stdout } = setupCapture();
+    const program = buildProgram(client, 'org1', 'proj1', true);
+    await program.parseAsync(['node', 'yunxiao', 'wi', 'list']);
+    const output = JSON.parse(stdout.join(''));
+    assert.ok('total' in output);
+    assert.ok(Array.isArray(output.items));
+    assert.equal(typeof output.total, 'number');
+  });
+  // ...
+});
+
+describe('命令层：AUTH_MISSING 错误', () => { ... });
+describe('命令层：--json 模式下 API 错误', () => { ... });
+describe('output 模块：printJson / printError 格式验证', () => { ... });
+```
+
+### 技术约束
+
+- Node.js ≥ 18，ESM（`"type": "module"`），2 空格缩进，单引号字符串
+- 不引入新依赖（Commander 已在 dependencies 中）
+- `import { Command } from 'commander'`（无 `.js` 后缀，node_modules 包）
+- `import { registerWorkitemCommands } from '../src/commands/workitem.js'`（带 `.js`）
+- `import { printJson, printError } from '../src/output.js'`（带 `.js`）
+- `npm test` 脚本：`node --test test/*.test.js`（自动包含新文件）
+
+### 已有基础设施
+
+- `test/setup.js`：`createMockClient()`、`makeWorkitem()`、`makePage()`、`makeProject()`、`makeSprint()`
+- `test/mock-example.test.js`：Strategy A/B 完整示例
+- `src/commands/workitem.js`：`registerWorkitemCommands(program, client, orgId, defaultProjectId, withErrorHandling, currentUserId, jsonMode)`
+- `src/output.js`：`printJson(data)` → stdout；`printError(code, message, jsonMode)` → stderr
+- `src/errors.js`：`AppError`、`ERROR_CODE`
+
+### 已有类似命令层测试参考
+
+`test/wi-view.test.js` 测试的是 API 层函数（`resolveWorkitemId` / `getWorkitem`），而非命令层。本 Story 是**首个真正的命令层测试**，需要 Commander 程序调用 + 输出捕获。
+
+### Project Structure Notes
+
+```
+test/
+  commands.test.js          ← 本 Story 新建：命令层测试
+  config.test.js            ← 已有（无需修改）
+  mock-example.test.js      ← 已有（参考用）
+  resolve.test.js           ← 已有（7-3 成果）
+  setup.js                  ← 已有共享 helpers（无需修改）
+  api.test.js               ← 已有（7-2 成果）
+  wi-view.test.js           ← 已有（2-3 成果）
+  workitem-delete.test.js   ← 已有（2-6 成果）
+  sprint.test.js            ← 已有
+  pipeline*.test.js         ← 已有
+  user.test.js              ← 已有
+src/
+  commands/workitem.js      ← 被测命令层（不修改）
+  output.js                 ← 被测输出函数（不修改）
+  errors.js                 ← AppError / ERROR_CODE（不修改）
+  index.js                  ← 不 import（会触发 CLI 启动逻辑）
+```
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/epics.md#Story 7.4] — 原始 AC
+- [Source: src/commands/workitem.js#registerWorkitemCommands] — 被测命令层入口
+- [Source: src/index.js#withErrorHandling] — 错误处理逻辑（行 28–44）
+- [Source: src/output.js] — printJson / printError
+- [Source: src/errors.js] — AppError / ERROR_CODE
+- [Source: src/api.js#searchWorkitems] — 返回 { items, total }（行 87–97）
+- [Source: test/setup.js] — createMockClient, makeWorkitem
+- [Source: test/mock-example.test.js] — Strategy A mock 示例
+- [Source: _bmad-output/implementation-artifacts/7-1-test-infrastructure.md] — ESM mock 限制
+- [Source: _bmad-output/implementation-artifacts/7-3-serial-number-tests.md#Dev Notes] — 前序测试 learnings
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-sonnet-4-6
+
+### Debug Log References
+
+### Completion Notes List
+
+- `test/commands.test.js` 新建，16 个测试用例全部通过（150 total / 150 pass / 0 fail，无回归）。
+- 核心技术：Strategy A（mock client.post HTTP 层）+ process.stdout/stderr/exit mock 捕获输出。
+- `setupCapture()` helper 通过 `mock.method` 拦截输出，`afterEach(() => mock.restoreAll())` 确保清理。
+- `buildWithErrorHandling(jsonMode)` 复制 index.js 逻辑（不 import 入口文件，避免 CLI 初始化副作用）。
+- `buildProgram()` 使用 `program.exitOverride()` 防止 Commander 自身调用 process.exit。
+- `MockExit` class 替换 process.exit，允许测试捕获退出码而不终止进程。
+- AC1 验证：stdout JSON 含 `total` 字段（包括 x-total header 解析路径）。
+- AC2 验证：AUTH_MISSING 错误码 + exit(1) + stderr JSON 格式。
+- AC3 验证：HTTP 500/404 → stdout 空 + stderr JSON 错误格式。
+- 额外覆盖：printJson/printError 格式契约、网络错误（无 response）→ API_ERROR。
+
+### File List
+
+- `test/commands.test.js` — 新建：命令层测试（16 个用例）
+
+### Review Findings
+
+- [x] [Review][Patch] Silent `catch(e)` blocks lack MockExit guards — add `if (!(e instanceof MockExit)) throw e;` [test/commands.test.js:237,261,281,295,191,207]
+- [x] [Review][Defer] `buildWithErrorHandling` duplicates `src/index.js` logic; divergence risk if production changes [test/commands.test.js:56-72] — deferred, pre-existing design constraint (index.js cannot be imported)
+- [x] [Review][Defer] `wi list` non-JSON mode command path untested [test/commands.test.js] — deferred, out of scope for Story 7.4
+- [x] [Review][Defer] `rawData?.total` branch (nested `{ data, total }` format) not exercised [test/commands.test.js] — deferred, out of scope
+- [x] [Review][Defer] 401→`AUTH_FAILED` path not tested [test/commands.test.js] — deferred, out of scope
+- [x] [Review][Defer] `err.message` undefined case not tested [test/commands.test.js] — deferred, out of scope
+- [x] [Review][Defer] Both `errorMessage` and `statusText` falsy not tested [test/commands.test.js] — deferred, out of scope
+- [x] [Review][Defer] AUTH_MISSING tested via direct throw, not through full `buildProgram`+`parseAsync` path [test/commands.test.js] — deferred, spec explicitly tests withErrorHandling wrapper directly
+- [x] [Review][Defer] `workitem.js` internal `process.exit` calls before withErrorHandling could surface MockExit as API_ERROR [test/commands.test.js] — deferred, out of scope

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -1,0 +1,12 @@
+# Deferred Work
+
+## Deferred from: code review of 7-4-command-layer-tests (2026-04-02)
+
+- `buildWithErrorHandling` duplicates `src/index.js` logic; divergence risk if production changes. Fix: export from a shared module or find a way to import without triggering CLI init.
+- `wi list` non-JSON mode command path (human-readable output) not tested — consider adding in a future test coverage story.
+- `rawData?.total` branch (nested `{ data: [...], total: N }` format) not exercised — add test case when pagination spec is clarified.
+- 401 HTTP response → `AUTH_FAILED` AppError path not tested through command layer.
+- `err.message` being `undefined` (e.g., `throw {}`) case not covered in `buildWithErrorHandling` else branch.
+- Both `errorMessage` and `statusText` being falsy/empty not tested — edge case produces `{"error":"","code":"API_ERROR"}`.
+- AUTH_MISSING tested via direct `AppError` throw, not through `buildProgram`+`parseAsync` dispatch. Real guard is in `src/index.js` `authRequiredAction`.
+- `workitem.js` has internal `process.exit` calls (INVALID_ARGS guard) that would throw `MockExit` and surface as spurious `API_ERROR` through `withErrorHandling` else branch.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-03-31
-last_updated: 2026-04-02  # story 7-3 done, story 2-2 done
+last_updated: 2026-04-02  # story 7-4 done
 project: yunxiao-cli
 project_key: NOKEY
 tracking_system: file-system
@@ -99,7 +99,7 @@ development_status:
   7-1-test-infrastructure: done
   7-2-api-layer-tests: done
   7-3-serial-number-tests: done
-  7-4-command-layer-tests: backlog
+  7-4-command-layer-tests: done
   epic-7-retrospective: optional
 
   # Epic 8: 文档

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -1,0 +1,359 @@
+// test/commands.test.js
+// Story 7.4: 命令层测试
+// 测试 CLI 命令层的核心输出路径：--json 格式、错误码契约、Auth 缺失行为
+//
+// 测试策略：Strategy A — mock client.post/get（HTTP 层）
+//   src/commands/workitem.js 通过 ESM 直接 import api.js，模块导出为 sealed，
+//   无法用 mock.method() 替换。正确做法：传入 mock client 给 registerWorkitemCommands，
+//   通过 mock.method(client, 'post', ...) 控制 API 响应，让真实代码路径执行。
+//
+// 输出捕获：
+//   mock.method(process.stdout, 'write', ...) — 捕获 printJson 写入
+//   mock.method(process.stderr, 'write', ...) — 捕获 printError 写入
+//   mock.method(process, 'exit', ...)         — 阻止进程退出，记录 exit code
+//
+// 不 import src/index.js — 该文件是 CLI 入口，加载时会读取 config 并发 API 请求
+
+import { test, describe, afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { Command } from 'commander';
+import { registerWorkitemCommands } from '../src/commands/workitem.js';
+import { AppError, ERROR_CODE } from '../src/errors.js';
+import { printJson, printError } from '../src/output.js';
+import { createMockClient, makeWorkitem } from './setup.js';
+
+// ---------------------------------------------------------------------------
+// MockExit：替换 process.exit，防止测试进程被终止
+// ---------------------------------------------------------------------------
+class MockExit extends Error {
+  constructor(code) {
+    super(`process.exit(${code})`);
+    this.exitCode = code;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// setupCapture()：捕获 stdout/stderr 写入和 process.exit 调用
+// 在 afterEach 中调用 mock.restoreAll() 即可还原，无需手动 restore
+// ---------------------------------------------------------------------------
+function setupCapture() {
+  const stdout = [];
+  const stderr = [];
+  const exitCodes = [];
+  mock.method(process.stdout, 'write', (data) => { stdout.push(String(data)); return true; });
+  mock.method(process.stderr, 'write', (data) => { stderr.push(String(data)); return true; });
+  mock.method(process, 'exit', (code) => {
+    exitCodes.push(code ?? 0);
+    throw new MockExit(code);
+  });
+  return { stdout, stderr, exitCodes };
+}
+
+// ---------------------------------------------------------------------------
+// buildWithErrorHandling(jsonMode)：复制 src/index.js 中的 withErrorHandling 逻辑
+// 不能直接 import index.js（入口文件加载时会执行 CLI 初始化逻辑）
+// ---------------------------------------------------------------------------
+function buildWithErrorHandling(jsonMode) {
+  return (fn) => async (...args) => {
+    try {
+      await fn(...args);
+    } catch (err) {
+      if (err instanceof AppError) {
+        printError(err.code, err.message, jsonMode);
+      } else if (err.response) {
+        const code = err.response.status === 404 ? ERROR_CODE.NOT_FOUND : ERROR_CODE.API_ERROR;
+        printError(code, err.response.data?.errorMessage || err.response.statusText, jsonMode);
+      } else {
+        printError(ERROR_CODE.API_ERROR, err.message, jsonMode);
+      }
+      process.exit(1);
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// buildProgram(client, orgId, projectId, jsonMode)：构建 Commander 程序
+// exitOverride()    → 防止 Commander 内部调用 process.exit（parse 错误时抛 CommanderError）
+// configureOutput() → 抑制 Commander 自身的错误输出（不污染 stderr 捕获）
+// ---------------------------------------------------------------------------
+function buildProgram(client, orgId, projectId, jsonMode) {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({ writeErr: () => {} });
+  program.option('--json', 'Output as JSON');
+  const withErrorHandling = buildWithErrorHandling(jsonMode);
+  registerWorkitemCommands(program, client, orgId, projectId, withErrorHandling, null, jsonMode);
+  return program;
+}
+
+// ---------------------------------------------------------------------------
+// AC1: wi list --json → stdout 是合法 JSON 且包含 total 字段
+// ---------------------------------------------------------------------------
+describe('命令层：wi list --json 输出格式', () => {
+  afterEach(() => mock.restoreAll());
+
+  test('stdout 是合法 JSON 且包含 total 字段', async () => {
+    const client = createMockClient();
+    const items = [makeWorkitem({ id: 'wi-001' }), makeWorkitem({ id: 'wi-002' })];
+    // searchWorkitems: client.post 返回 { data: array } → items=array, total=items.length
+    mock.method(client, 'post', async () => ({ data: items }));
+
+    const { stdout } = setupCapture();
+    const program = buildProgram(client, 'org1', 'proj1', true);
+
+    await program.parseAsync(['node', 'yunxiao', 'wi', 'list']);
+
+    assert.ok(stdout.length > 0, 'stdout 应有输出');
+    const output = JSON.parse(stdout.join(''));
+    assert.ok('total' in output, 'JSON 输出应包含 total 字段');
+    assert.ok(Array.isArray(output.items), 'JSON 输出应包含 items 数组');
+    assert.equal(typeof output.total, 'number', 'total 应为数字类型');
+  });
+
+  test('items 数组长度与 mock 数据一致', async () => {
+    const client = createMockClient();
+    const items = [makeWorkitem(), makeWorkitem(), makeWorkitem()];
+    mock.method(client, 'post', async () => ({ data: items }));
+
+    const { stdout } = setupCapture();
+    const program = buildProgram(client, 'org1', 'proj1', true);
+
+    await program.parseAsync(['node', 'yunxiao', 'wi', 'list']);
+
+    const output = JSON.parse(stdout.join(''));
+    assert.equal(output.items.length, 3);
+    assert.equal(output.total, 3);
+  });
+
+  test('x-total header 被解析为 total 值（override items.length）', async () => {
+    const client = createMockClient();
+    const items = [makeWorkitem({ id: 'wi-page1' })];
+    // x-total header 表示服务端总数（可大于当前页 items 数量）
+    mock.method(client, 'post', async () => ({
+      data: items,
+      headers: { 'x-total': '42' },
+    }));
+
+    const { stdout } = setupCapture();
+    const program = buildProgram(client, 'org1', 'proj1', true);
+
+    await program.parseAsync(['node', 'yunxiao', 'wi', 'list']);
+
+    const output = JSON.parse(stdout.join(''));
+    assert.equal(output.total, 42, 'total 应来自 x-total header');
+    assert.equal(output.items.length, 1, 'items 仍为当前页数量');
+  });
+
+  test('API 返回空数组时，total=0，items=[]', async () => {
+    const client = createMockClient();
+    mock.method(client, 'post', async () => ({ data: [] }));
+
+    const { stdout } = setupCapture();
+    const program = buildProgram(client, 'org1', 'proj1', true);
+
+    await program.parseAsync(['node', 'yunxiao', 'wi', 'list']);
+
+    const output = JSON.parse(stdout.join(''));
+    assert.equal(output.total, 0);
+    assert.deepEqual(output.items, []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC2: 认证缺失 → stderr 含 AUTH_MISSING 错误码，退出码非零
+// ---------------------------------------------------------------------------
+describe('命令层：AUTH_MISSING 错误处理', () => {
+  afterEach(() => mock.restoreAll());
+
+  test('withErrorHandling 捕获 AUTH_MISSING → stderr 含错误码，exit(1)', async () => {
+    const { stderr, exitCodes } = setupCapture();
+    const withErrorHandling = buildWithErrorHandling(true);
+
+    try {
+      await withErrorHandling(async () => {
+        throw new AppError(ERROR_CODE.AUTH_MISSING, 'Authentication required. Run: yunxiao auth login');
+      })();
+    } catch (e) {
+      assert.ok(e instanceof MockExit, '应抛出 MockExit');
+    }
+
+    assert.equal(exitCodes[0], 1, 'exit code 应为 1');
+    assert.ok(stderr.length > 0, 'stderr 应有输出');
+    const errOutput = JSON.parse(stderr.join(''));
+    assert.equal(errOutput.code, ERROR_CODE.AUTH_MISSING);
+    assert.ok(typeof errOutput.error === 'string', 'error 字段应为字符串');
+  });
+
+  test('AUTH_MISSING: stderr 格式为 {"error":"...","code":"AUTH_MISSING"}', async () => {
+    const { stderr } = setupCapture();
+    const withErrorHandling = buildWithErrorHandling(true);
+
+    try {
+      await withErrorHandling(async () => {
+        throw new AppError(ERROR_CODE.AUTH_MISSING, 'Authentication required');
+      })();
+    } catch (e) { if (!(e instanceof MockExit)) throw e; }
+
+    const errOutput = JSON.parse(stderr.join(''));
+    assert.equal(errOutput.code, 'AUTH_MISSING');
+    assert.ok('error' in errOutput, 'stderr JSON 应含 error 字段');
+    assert.ok(!('stack' in errOutput), 'stderr JSON 不应暴露 stack trace');
+  });
+
+  test('AUTH_MISSING: stdout 无输出', async () => {
+    const { stdout } = setupCapture();
+    const withErrorHandling = buildWithErrorHandling(true);
+
+    try {
+      await withErrorHandling(async () => {
+        throw new AppError(ERROR_CODE.AUTH_MISSING, 'Auth missing');
+      })();
+    } catch (e) { if (!(e instanceof MockExit)) throw e; }
+
+    assert.equal(stdout.join(''), '', 'AUTH_MISSING 错误时 stdout 应无输出');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC3: --json 模式下 API 错误 → stdout 无输出，stderr 含 JSON 错误格式
+// ---------------------------------------------------------------------------
+describe('命令层：--json 模式下 API 错误', () => {
+  afterEach(() => mock.restoreAll());
+
+  test('HTTP 500 错误：stdout 无输出，stderr 含 {"error":"...","code":"API_ERROR"}', async () => {
+    const client = createMockClient();
+    const apiErr = Object.assign(new Error('Internal Server Error'), {
+      response: {
+        status: 500,
+        data: { errorMessage: 'server error' },
+        statusText: 'Internal Server Error',
+      },
+    });
+    mock.method(client, 'post', async () => { throw apiErr; });
+
+    const { stdout, stderr } = setupCapture();
+    const program = buildProgram(client, 'org1', 'proj1', true);
+
+    try {
+      await program.parseAsync(['node', 'yunxiao', 'wi', 'list']);
+    } catch (e) { if (!(e instanceof MockExit)) throw e; }
+
+    assert.equal(stdout.join(''), '', 'API 错误时 stdout 应无输出');
+    const errOutput = JSON.parse(stderr.join(''));
+    assert.equal(errOutput.code, 'API_ERROR');
+    assert.ok(typeof errOutput.error === 'string');
+  });
+
+  test('HTTP 404 错误：stderr 含 {"error":"...","code":"NOT_FOUND"}', async () => {
+    const client = createMockClient();
+    const notFoundErr = Object.assign(new Error('Not Found'), {
+      response: {
+        status: 404,
+        data: { errorMessage: 'workitem not found' },
+        statusText: 'Not Found',
+      },
+    });
+    mock.method(client, 'post', async () => { throw notFoundErr; });
+
+    const { stdout, stderr } = setupCapture();
+    const program = buildProgram(client, 'org1', 'proj1', true);
+
+    try {
+      await program.parseAsync(['node', 'yunxiao', 'wi', 'list']);
+    } catch (e) { if (!(e instanceof MockExit)) throw e; }
+
+    assert.equal(stdout.join(''), '', '404 错误时 stdout 应无输出');
+    const errOutput = JSON.parse(stderr.join(''));
+    assert.equal(errOutput.code, 'NOT_FOUND');
+  });
+
+  test('exit code 为 1（非零）', async () => {
+    const client = createMockClient();
+    const apiErr = Object.assign(new Error('Bad Gateway'), {
+      response: { status: 502, data: {}, statusText: 'Bad Gateway' },
+    });
+    mock.method(client, 'post', async () => { throw apiErr; });
+
+    const { exitCodes } = setupCapture();
+    const program = buildProgram(client, 'org1', 'proj1', true);
+
+    try {
+      await program.parseAsync(['node', 'yunxiao', 'wi', 'list']);
+    } catch (e) { if (!(e instanceof MockExit)) throw e; }
+
+    assert.ok(exitCodes.length > 0, 'process.exit 应被调用');
+    assert.equal(exitCodes[0], 1, 'exit code 应为 1');
+  });
+
+  test('无 response 属性的错误（网络异常）→ stderr 含 API_ERROR', async () => {
+    const client = createMockClient();
+    mock.method(client, 'post', async () => { throw new Error('ECONNREFUSED'); });
+
+    const { stdout, stderr } = setupCapture();
+    const program = buildProgram(client, 'org1', 'proj1', true);
+
+    try {
+      await program.parseAsync(['node', 'yunxiao', 'wi', 'list']);
+    } catch (e) { if (!(e instanceof MockExit)) throw e; }
+
+    assert.equal(stdout.join(''), '', '网络错误时 stdout 应无输出');
+    const errOutput = JSON.parse(stderr.join(''));
+    assert.equal(errOutput.code, 'API_ERROR');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// output 模块：printJson / printError 格式契约验证
+// ---------------------------------------------------------------------------
+describe('output 模块：printJson / printError 格式验证', () => {
+  afterEach(() => mock.restoreAll());
+
+  test('printJson: stdout 输出合法 JSON，以换行结尾', () => {
+    const { stdout } = setupCapture();
+    printJson({ items: [{ id: 'x' }], total: 1 });
+
+    const raw = stdout.join('');
+    assert.ok(raw.endsWith('\n'), 'JSON 输出应以换行结尾');
+    const parsed = JSON.parse(raw.trim());
+    assert.equal(parsed.total, 1);
+    assert.equal(parsed.items[0].id, 'x');
+  });
+
+  test('printJson: 可序列化为嵌套对象', () => {
+    const { stdout } = setupCapture();
+    printJson({ nested: { a: 1 }, arr: [1, 2, 3] });
+
+    const parsed = JSON.parse(stdout.join('').trim());
+    assert.equal(parsed.nested.a, 1);
+    assert.deepEqual(parsed.arr, [1, 2, 3]);
+  });
+
+  test('printError jsonMode=true: stderr 输出 {"error":"...","code":"..."} 格式', () => {
+    const { stderr } = setupCapture();
+    printError('API_ERROR', 'something went wrong', true);
+
+    const errOutput = JSON.parse(stderr.join(''));
+    assert.equal(errOutput.code, 'API_ERROR');
+    assert.equal(errOutput.error, 'something went wrong');
+  });
+
+  test('printError jsonMode=true: 所有 ERROR_CODE 均可正确输出', () => {
+    for (const code of Object.values(ERROR_CODE)) {
+      const { stderr } = setupCapture();
+      printError(code, `test error for ${code}`, true);
+      mock.restoreAll();
+
+      const errOutput = JSON.parse(stderr.join(''));
+      assert.equal(errOutput.code, code, `ERROR_CODE.${code} 应正确写入 stderr`);
+    }
+  });
+
+  test('printError jsonMode=false: stderr 输出人类可读格式（含错误码和消息）', () => {
+    const { stderr } = setupCapture();
+    printError('AUTH_MISSING', 'not authenticated', false);
+
+    const raw = stderr.join('');
+    assert.ok(raw.includes('AUTH_MISSING'), '非 json 模式应包含错误码');
+    assert.ok(raw.includes('not authenticated'), '非 json 模式应包含错误消息');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `test/commands.test.js` with 16 test cases covering Story 7.4 (命令层测试)
- Tests the CLI command layer end-to-end using Commander.js `parseAsync()` + captured process streams
- Strategy A: mock `client.post` HTTP layer so real `api.js` code paths execute with controlled responses

## Acceptance Criteria Coverage

- **AC1** (`wi list --json`): stdout is valid JSON with `total` (number) + `items` (array); `x-total` header parsed as total
- **AC2** (AUTH_MISSING): `exit(1)`, stderr JSON `{"error":"...","code":"AUTH_MISSING"}`, stdout empty
- **AC3** (API errors): HTTP 500→`API_ERROR`, 404→`NOT_FOUND`, network error→`API_ERROR`; stdout empty in all cases
- **Extra**: `printJson`/`printError` format contract tests for all `ERROR_CODE` values in both modes

## Key Implementation

- `MockExit` class: replaces `process.exit` via `mock.method`, throws instead of terminating process
- `setupCapture()`: intercepts `process.stdout.write`, `process.stderr.write`, `process.exit`
- `buildWithErrorHandling()`: replicates `src/index.js` logic (cannot import — CLI entry triggers init)
- `buildProgram()`: uses `program.exitOverride()` to prevent Commander from calling `process.exit`

## Test plan

- [ ] `npm test` passes: 150 tests, 150 pass, 0 fail
- [ ] No regression in existing test suites
- [ ] Code review passed (1 patch applied: MockExit guards in catch blocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)