### PR TITLE
fix(cli): restore version-check startup path

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-03-31
-last_updated: 2026-04-17  # Story 10-1 done
+last_updated: 2026-04-17  # Story 9-5 formal delivery closed; Epic 9 done
 project: yunxiao-cli
 project_key: NOKEY
 tracking_system: file-system
@@ -111,7 +111,7 @@ development_status:
   epic-8-retrospective: done  # 全项目复盘 2026-04-02
 
   # Epic 9: 稳定性修复与 v0.2 增强
-  epic-9: in-progress
+  epic-9: done
   9-1-auth-login-pat-url-fix: done
   9-2-project-list-layout-fix: done
   9-3-resolve-workitem-id-pagination: done

--- a/src/index.js
+++ b/src/index.js
@@ -54,8 +54,6 @@ function withErrorHandling(fn) {
 // Register auth commands first (they don't require a client)
 registerAuthCommands(program);
 
-// Load config with correct priority: file > env vars (CLI args handled per-command)
-const config = loadConfig();
 const token = config.token;
 
 let client = null;
@@ -97,8 +95,6 @@ registerQueryCommands(program, client, orgId, projectId, withErrorHandling, json
 // Check for version updates (non-blocking, async)
 checkVersionAsync().then(({ hasUpdate, latestVersion }) => {
   if (hasUpdate && latestVersion) {
-    const packageJson = JSON.parse(require('fs').readFileSync(new URL('../package.json', import.meta.url), 'utf-8'));
-    const localVersion = packageJson.version;
     process.stderr.write(`yunxiao v${latestVersion} available, run \`npm update -g @kongsiyu/yunxiao-cli\` to update\n`);
   }
 }).catch(() => {

--- a/test/version-check.test.js
+++ b/test/version-check.test.js
@@ -4,6 +4,8 @@ import assert from 'node:assert';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'url';
 import { checkVersionAsync, getVersionCheckCacheFileForTest, setTestCacheFile } from '../src/version-check.js';
 
 // Mock cache directory for testing
@@ -192,4 +194,38 @@ test('version check - cache file path exists', () => {
   assert.strictEqual(typeof cacheFile, 'string');
   assert(cacheFile.includes('.yunxiao'));
   assert(cacheFile.includes('version-check-cache.json'));
+});
+
+test('cli entrypoint prints update notice from cache during a normal command', () => {
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'yunxiao-cli-home-'));
+  const cacheDir = path.join(tempHome, '.yunxiao');
+  const repoRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const packageJson = JSON.parse(
+    fs.readFileSync(new URL('../package.json', import.meta.url), 'utf-8')
+  );
+
+  try {
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(cacheDir, 'version-check-cache.json'),
+      JSON.stringify({
+        lastCheckTime: Date.now(),
+        latestVersion: '9.9.9',
+        localVersion: packageJson.version
+      }),
+      'utf-8'
+    );
+
+    const result = spawnSync(process.execPath, ['src/index.js', 'auth', 'status'], {
+      cwd: repoRoot,
+      env: { ...process.env, HOME: tempHome },
+      encoding: 'utf-8'
+    });
+
+    assert.strictEqual(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /Authentication Status/i);
+    assert.match(result.stderr, /yunxiao v9\.9\.9 available/i);
+  } finally {
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary

Recover Story 9.5 startup behavior on a clean story branch.

- remove the duplicate `config` declaration that made the CLI fail at parse time
- remove the CommonJS `require(...)` usage from the ESM entrypoint version-check path
- add a CLI smoke test that verifies a normal command can emit the cached update notice on stderr

## Test plan

- [x] `npm run lint`
- [x] `node --test test/version-check.test.js`
- [x] `npm test`
- [x] `node src/index.js --help`

Context:
- existing Story 9.5 commits had landed in `master`, but the shipped entrypoint still had a real startup regression
- this PR fixes that runtime path on a new story branch only; no PR merge operations performed here
