### PR TITLE
fix(release): align CLI version metadata for v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kongsiyu/yunxiao-cli",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kongsiyu/yunxiao-cli",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongsiyu/yunxiao-cli",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "CLI for Aliyun Yunxiao DevOps platform",
   "type": "module",
   "bin": {

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import { getCurrentUser, createClientWithPat } from "./api.js";
 import { loadConfig } from "./config.js";
 import { AppError, ERROR_CODE } from "./errors.js";
 import { printError } from "./output.js";
-import { checkVersionAsync } from "./version-check.js";
+import { checkVersionAsync, getPackageVersion } from "./version-check.js";
 import { initI18n } from "./i18n/index.js";
 import { registerProjectCommands } from "./commands/project.js";
 import { registerWorkitemCommands } from "./commands/workitem.js";
@@ -30,7 +30,7 @@ initI18n(config.language);
 program
   .name("yunxiao")
   .description("CLI for Aliyun Yunxiao (云效) DevOps platform")
-  .version("0.1.1")
+  .version(getPackageVersion() || "0.0.0")
   .option("--json", "Output results as JSON (pure JSON to stdout, no chalk)");
 
 function withErrorHandling(fn) {

--- a/src/version-check.js
+++ b/src/version-check.js
@@ -21,7 +21,7 @@ export function setTestCacheFile(filePath) {
   testCacheFilePath = filePath;
 }
 
-function readPackageVersion() {
+export function getPackageVersion() {
   try {
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
     return packageJson.version;
@@ -89,7 +89,7 @@ async function fetchLatestVersion() {
 }
 
 export async function checkVersionAsync() {
-  const localVersion = readPackageVersion();
+  const localVersion = getPackageVersion();
   if (!localVersion) return { hasUpdate: false, latestVersion: null };
 
   // Check cache first

--- a/test/version-check.test.js
+++ b/test/version-check.test.js
@@ -6,7 +6,7 @@ import path from 'path';
 import os from 'os';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'url';
-import { checkVersionAsync, getVersionCheckCacheFileForTest, setTestCacheFile } from '../src/version-check.js';
+import { checkVersionAsync, getPackageVersion, getVersionCheckCacheFileForTest, setTestCacheFile } from '../src/version-check.js';
 
 // Mock cache directory for testing
 const testCacheDir = path.join(os.tmpdir(), 'yunxiao-test-cache');
@@ -153,11 +153,16 @@ test('version comparison - minor version difference', async () => {
 });
 
 test('version comparison - patch version difference', async () => {
+  const packageJson = JSON.parse(
+    fs.readFileSync(new URL('../package.json', import.meta.url), 'utf-8')
+  );
+  const [major, minor, patch] = packageJson.version.split('.').map(Number);
+
   setupTestCache();
   writeMockCache({
     lastCheckTime: Date.now(),
-    latestVersion: '1.0.2',
-    localVersion: '1.0.1'
+    latestVersion: `${major}.${minor}.${patch + 1}`,
+    localVersion: packageJson.version
   });
 
   const result = await checkVersionAsync();
@@ -196,6 +201,14 @@ test('version check - cache file path exists', () => {
   assert(cacheFile.includes('version-check-cache.json'));
 });
 
+test('package version helper reads current package.json version', () => {
+  const packageJson = JSON.parse(
+    fs.readFileSync(new URL('../package.json', import.meta.url), 'utf-8')
+  );
+
+  assert.strictEqual(getPackageVersion(), packageJson.version);
+});
+
 test('cli entrypoint prints update notice from cache during a normal command', () => {
   const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'yunxiao-cli-home-'));
   const cacheDir = path.join(tempHome, '.yunxiao');
@@ -228,4 +241,20 @@ test('cli entrypoint prints update notice from cache during a normal command', (
   } finally {
     fs.rmSync(tempHome, { recursive: true, force: true });
   }
+});
+
+test('cli --version matches package.json version', () => {
+  const repoRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const packageJson = JSON.parse(
+    fs.readFileSync(new URL('../package.json', import.meta.url), 'utf-8')
+  );
+
+  const result = spawnSync(process.execPath, ['src/index.js', '--version'], {
+    cwd: repoRoot,
+    env: { ...process.env },
+    encoding: 'utf-8'
+  });
+
+  assert.strictEqual(result.status, 0, result.stderr || result.stdout);
+  assert.strictEqual(result.stdout.trim(), packageJson.version);
 });


### PR DESCRIPTION
## Summary
- bump package version metadata from `1.0.0` to `1.1.0`
- make the CLI read its runtime version from `package.json` instead of a stale hardcoded string
- add regression coverage so `yunxiao --version` stays aligned with the published package version

## Why
This is the minimal pre-release fix required for HTH-189. Without it, publishing the next release would still report the old CLI version at runtime.

## Verification
- `npm test`
- `npm run lint`
- `npm pack --dry-run`
