### PR TITLE
test(smoke): add real CLI smoke matrix runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,6 +783,53 @@ yunxiao sprint view <sprintId>
 yunxiao wi list --sprint <sprintId>
 ```
 
+## Smoke 验证
+
+真实 CLI smoke 通过 `node` 子进程直接执行 `src/index.js`，不走命令层 mock。runner 会为每个 case 创建独立的临时 `HOME`，并预写 `.yunxiao/version-check-cache.json`，避免污染本机配置或让版本检查噪音干扰 stdout/stderr 判定。
+
+### CI 安全 smoke
+
+```bash
+npm run smoke
+```
+
+该命令会执行无需真实 PAT 的 case：
+
+- `yunxiao --version`
+- `yunxiao --help`
+- `yunxiao auth status`（空配置）
+- `yunxiao project list --json` 的 `AUTH_MISSING` 失败路径
+- 中文 human-readable 路径：`yunxiao auth login` 空 PAT 提示
+
+需要真实环境的 case 仍会出现在 matrix 中，但在 `npm run smoke` 下会被标记为 `skipped`，不会导致 CI 假失败。
+
+### Live smoke
+
+```bash
+export YUNXIAO_SMOKE_PAT=your_pat
+export YUNXIAO_SMOKE_ORG_ID=your_org_id
+export YUNXIAO_SMOKE_PROJECT_ID=your_project_id
+npm run smoke:live
+```
+
+可选变量：
+
+- `YUNXIAO_SMOKE_LANGUAGE`：写入临时 smoke config 的 `language`
+
+`npm run smoke:live` 会在 CI 安全 case 之外，额外执行以下真实环境命令：
+
+- `yunxiao project list --json`
+- `yunxiao wi list --json`
+- `yunxiao sprint list --json`
+
+### 预期输出与失败判定
+
+- `--version` 必须与 `package.json` 中的 `version` 完全一致。
+- 成功的 `--json` case 必须满足：stdout 为可解析的纯 JSON，stderr 为空。
+- 失败路径 case 必须满足：stdout 为空，stderr 为稳定的错误输出（如 `AUTH_MISSING` JSON）。
+- 中文 human-readable case 必须在 stdout 中看到中文提示。
+- `smoke:live` 缺少任一必填环境变量会直接失败，不进入真实 API 调用。
+
 ## 版本历史
 
 - **v0.1.1** - 认证命令：auth login/status/logout

--- a/_bmad-output/implementation-artifacts/12-1-real-cli-smoke-matrix.md
+++ b/_bmad-output/implementation-artifacts/12-1-real-cli-smoke-matrix.md
@@ -1,0 +1,147 @@
+# Story 12-1：真实 CLI smoke matrix 与执行入口
+
+**Story ID**: 12.1
+**Epic**: 12 - v1.2.0 AI workflow 契约加固与 release gate
+**Status**: done
+**Created**: 2026-04-19
+**Author**: Sue (PM Senior)
+
+---
+
+## 用户故事
+
+As a release reviewer,
+I want a real CLI smoke matrix and runnable entrypoint,
+So that version metadata, stdout/stderr behavior, and common command paths are verified outside unit-test mocks.
+
+---
+
+## 验收标准
+
+### AC1：smoke matrix 覆盖范围
+**Given** v1.2.0 高频命令范围
+**When** 定义 smoke matrix
+**Then** matrix 至少包含 `yunxiao --version`、`yunxiao --help`、`auth status`、`project list --json`、`wi list --json`、`sprint list --json`、一个失败路径和一个中文 human-readable 路径
+
+### AC2：无真实 PAT 的自动 smoke
+**Given** 无真实 PAT 的 CI 环境
+**When** 运行 smoke
+**Then** 可执行无需认证的 smoke
+**And** 需真实环境的项目标记为 live/manual，不导致 CI 假失败
+
+### AC3：真实环境 live smoke
+**Given** 有真实 PAT / org / project 环境
+**When** 运行 live smoke
+**Then** 验证 stdout 纯 JSON、提示写 stderr、错误码稳定、runtime version 与 `package.json` 对齐
+
+### AC4：交付文档
+**Given** smoke 入口完成
+**When** 准备交付
+**Then** 文档化执行命令、环境变量、预期输出和失败判定
+
+---
+
+## Tasks / Subtasks
+
+- [x] Task 1: 定义 smoke matrix 与执行分层 (AC: AC1, AC2, AC3)
+  - [x] Subtask 1.1: 固化至少 8 个 smoke case，覆盖版本、帮助、认证状态、JSON 命令、失败路径与中文 human-readable 路径
+  - [x] Subtask 1.2: 为每个 case 标注 `ci` 或 `live/manual` 执行层级，确保无真实 PAT 时只跑无需认证项
+  - [x] Subtask 1.3: 对齐 Epic 11.1 当前已知高频命令范围，若缺少 11.1 工件则以 `epics.md` / `prd.md` 中锁定范围为准
+
+- [x] Task 2: 实现真实 CLI smoke 执行入口 (AC: AC1, AC2, AC3)
+  - [x] Subtask 2.1: 新增基于真实子进程的 smoke runner，直接执行 `node src/index.js ...`
+  - [x] Subtask 2.2: 使用隔离的临时 `HOME` / `.yunxiao/config.json`，避免污染当前用户配置
+  - [x] Subtask 2.3: 支持 `ci` 与 `live` 两种模式，并在 `package.json` 中暴露可执行入口
+  - [x] Subtask 2.4: 为成功 JSON case 验证 stdout 纯 JSON、stderr 仅允许提示类输出；为失败 case 验证错误码与退出码
+
+- [x] Task 3: 为 smoke runner 增加自动化测试 (AC: AC2, AC3)
+  - [x] Subtask 3.1: 测试 matrix 定义包含必需 case 且 live case 被正确标记
+  - [x] Subtask 3.2: 测试 `ci` 模式在无认证环境下可通过，并将 live case 记为 skip
+  - [x] Subtask 3.3: 测试 live 模式前置检查，缺少必需环境变量时给出明确失败原因
+
+- [x] Task 4: 文档化 smoke 命令、环境变量与判定标准 (AC: AC4)
+  - [x] Subtask 4.1: 在 README 中补充 `npm run smoke` / `npm run smoke:live` 的使用方式
+  - [x] Subtask 4.2: 文档化 `YUNXIAO_SMOKE_PAT`、`YUNXIAO_SMOKE_ORG_ID`、`YUNXIAO_SMOKE_PROJECT_ID` 等变量
+  - [x] Subtask 4.3: 文档化每类 case 的预期输出与失败判定
+
+- [x] Task 5: 完成验证与交付记录 (AC: AC1, AC2, AC3, AC4)
+  - [x] Subtask 5.1: 运行 `npm test`
+  - [x] Subtask 5.2: 运行 `npm run smoke`
+  - [x] Subtask 5.3: 若具备真实环境则运行 `npm run smoke:live`；若当前会话不具备，则在文档与 Completion Notes 中明确说明
+
+---
+
+## 架构与实现护栏
+
+### 代码结构要求
+
+优先在以下范围内实现：
+- `scripts/smoke/`
+- `package.json`
+- `README.md`
+- `test/`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+
+不要为了本 Story 改写现有命令实现逻辑，除非 smoke runner 发现确定的契约缺口必须修复。
+
+### 已知项目约束
+
+- 当前仓库没有独立 architecture 文档或 project-context 文档；实现约束以 `README.md`、`src/index.js`、`src/output.js`、`src/errors.js`、`src/config.js`、现有测试模式为准。
+- 当前 `package.json` 版本为 `1.1.0`，`src/index.js` 的 `program.version(getPackageVersion() || "0.0.0")` 已把运行时版本绑定到 `package.json`。
+- `--json` 成功输出走 stdout，`printError()` 在 JSON 模式下把错误 JSON 写入 stderr。
+- 版本检查可能在成功命令的 stderr 输出升级提示；smoke runner 应允许这种 advisory stderr，但不能让其污染 stdout JSON。
+
+### 与 Epic 11.1 的对齐约束
+
+- `epics.md` 当前锁定的高频命令范围是：`auth`、`whoami`、`project list`、`wi list/view/update`、`sprint list/view`。
+- 本 Story 至少覆盖 issue 指定的 `auth status`、`project list --json`、`wi list --json`、`sprint list --json`。
+- 当前分支内没有现成的 `11-1-i18n-audit-rollout-scope.md` 工件，因此中文 human-readable 路径以当前代码已存在且稳定的中文交互路径为准，不等待 11.2 完成。
+
+### 复用优先级
+
+- 复用 `node:child_process` 的真实子进程执行，而不是再次 mock 命令层。
+- 复用 `src/config.js` 的配置文件格式：`token`、`orgId`、`projectId`、`language`。
+- 复用现有 `node:test` 测试框架，不引入额外测试依赖。
+
+### 测试与交付要求
+
+- `npm test` 必跑。
+- `npm run smoke` 必跑。
+- live smoke 仅在显式提供真实环境变量时执行；CI 默认不得因 live case 缺少认证而失败。
+
+---
+
+## Dev Agent Record
+
+### Agent Model Used
+
+gpt-5.4
+
+### Debug Log References
+
+- 2026-04-19: Story 12.1 由 BMAD Developer 在 worktree 中创建
+- 2026-04-19: 基于 diff review 修正 smoke runner 的环境注入路径，确保 `runSmokeMode(..., { env })` 对子进程同样生效
+
+### Completion Notes List
+
+- 新增 `scripts/smoke/matrix.js` 与 `scripts/smoke/runner.js`，以真实 `node src/index.js ...` 子进程执行 smoke，而非命令层 mock。
+- 新增 `npm run smoke` 与 `npm run smoke:live` 入口；CI 模式会跳过 live/manual case，避免无 PAT 时误报失败。
+- 每个 smoke case 使用独立临时 `HOME`，并预写 `.yunxiao/version-check-cache.json`，避免版本检查输出干扰 JSON 断言，也不污染本机 `~/.yunxiao/config.json`。
+- 覆盖了 Story 要求的版本、帮助、`auth status`、失败路径、中文 human-readable 路径，以及 live 模式下的 `project list --json`、`wi list --json`、`sprint list --json`。
+- 代码审查阶段发现并修正了 smoke runner 使用自定义 `env` 时未完整传入子进程的问题。
+- 验证已完成：`npm test`、`npm run lint`、`npm run smoke`、`npm run smoke:live` 全部通过。
+
+### File List
+
+- _bmad-output/implementation-artifacts/12-1-real-cli-smoke-matrix.md (new)
+- _bmad-output/implementation-artifacts/sprint-status.yaml (updated: added Epic 12 tracking, story state done)
+- package.json (updated: added smoke scripts)
+- README.md (updated: added smoke usage, env vars, and pass/fail expectations)
+- scripts/smoke/matrix.js (new)
+- scripts/smoke/runner.js (new)
+- test/smoke.test.js (new)
+
+### Change Log
+
+- 2026-04-19: 初始化 Story 12.1 工件
+- 2026-04-19: 完成真实 CLI smoke matrix、runner、测试与 README 文档

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -128,3 +128,7 @@ development_status:
   10-4-mr-list: done
   10-5-mr-view: done
   10-6-mr-create: done
+  
+  # Epic 12: v1.2.0 AI workflow 契约加固与 release gate
+  epic-12: in-progress
+  12-1-real-cli-smoke-matrix: done

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   ],
   "scripts": {
     "lint": "node src/index.js --version",
-    "test": "node --test test/*.test.js"
+    "test": "node --test test/*.test.js",
+    "smoke": "node scripts/smoke/runner.js ci",
+    "smoke:live": "node scripts/smoke/runner.js live"
   },
   "keywords": [
     "yunxiao",

--- a/scripts/smoke/matrix.js
+++ b/scripts/smoke/matrix.js
@@ -1,0 +1,221 @@
+function pass(detail) {
+  return { ok: true, detail };
+}
+
+function fail(detail) {
+  return { ok: false, detail };
+}
+
+function normalizeText(value) {
+  return String(value || "").replace(/\r\n/g, "\n");
+}
+
+function parseJson(value) {
+  return JSON.parse(normalizeText(value).trim());
+}
+
+function validateJsonShape(result, fieldName) {
+  if (result.status !== 0) {
+    return fail(`expected exit 0, got ${result.status}`);
+  }
+
+  if (normalizeText(result.stderr).trim() !== "") {
+    return fail(`expected empty stderr, got: ${normalizeText(result.stderr).trim()}`);
+  }
+
+  let payload;
+  try {
+    payload = parseJson(result.stdout);
+  } catch (error) {
+    return fail(`stdout is not valid JSON: ${error.message}`);
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(payload, fieldName)) {
+    return fail(`stdout JSON is missing "${fieldName}"`);
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(payload, "total")) {
+    return fail('stdout JSON is missing "total"');
+  }
+
+  if (!Array.isArray(payload[fieldName])) {
+    return fail(`stdout JSON field "${fieldName}" is not an array`);
+  }
+
+  if (typeof payload.total !== "number") {
+    return fail('stdout JSON field "total" is not a number');
+  }
+
+  return pass(`stdout JSON contains ${fieldName}[${payload[fieldName].length}] and total=${payload.total}`);
+}
+
+export const LIVE_ENV_VARS = [
+  "YUNXIAO_SMOKE_PAT",
+  "YUNXIAO_SMOKE_ORG_ID",
+  "YUNXIAO_SMOKE_PROJECT_ID",
+];
+
+export const SMOKE_CASES = [
+  {
+    id: "version",
+    title: "runtime version matches package.json",
+    tier: "ci",
+    command: ["--version"],
+    profile: "clean",
+    validate(result, context) {
+      if (result.status !== 0) {
+        return fail(`expected exit 0, got ${result.status}`);
+      }
+      if (normalizeText(result.stderr).trim() !== "") {
+        return fail(`expected empty stderr, got: ${normalizeText(result.stderr).trim()}`);
+      }
+      const actual = normalizeText(result.stdout).trim();
+      if (actual !== context.packageVersion) {
+        return fail(`expected stdout "${context.packageVersion}", got "${actual}"`);
+      }
+      return pass(`stdout matched package.json version ${context.packageVersion}`);
+    },
+  },
+  {
+    id: "help",
+    title: "help output is reachable",
+    tier: "ci",
+    command: ["--help"],
+    profile: "clean",
+    validate(result) {
+      if (result.status !== 0) {
+        return fail(`expected exit 0, got ${result.status}`);
+      }
+      const stdout = normalizeText(result.stdout);
+      if (!stdout.includes("Usage: yunxiao")) {
+        return fail('stdout does not include "Usage: yunxiao"');
+      }
+      if (!stdout.includes("Commands:")) {
+        return fail('stdout does not include "Commands:"');
+      }
+      return pass("help output contains usage and command listing");
+    },
+  },
+  {
+    id: "auth-status-clean",
+    title: "auth status works without local config",
+    tier: "ci",
+    command: ["auth", "status"],
+    profile: "clean",
+    validate(result) {
+      if (result.status !== 0) {
+        return fail(`expected exit 0, got ${result.status}`);
+      }
+      const stdout = normalizeText(result.stdout);
+      if (!stdout.includes("Authentication Status:")) {
+        return fail('stdout does not include "Authentication Status:"');
+      }
+      if (!stdout.includes("Not authenticated")) {
+        return fail('stdout does not include "Not authenticated"');
+      }
+      if (normalizeText(result.stderr).trim() !== "") {
+        return fail(`expected empty stderr, got: ${normalizeText(result.stderr).trim()}`);
+      }
+      return pass("clean-home auth status reports unauthenticated without failing");
+    },
+  },
+  {
+    id: "project-list-json-auth-missing",
+    title: "failure path keeps JSON contract on stderr",
+    tier: "ci",
+    command: ["project", "list", "--json"],
+    profile: "clean",
+    validate(result) {
+      if (result.status !== 1) {
+        return fail(`expected exit 1, got ${result.status}`);
+      }
+      if (normalizeText(result.stdout).trim() !== "") {
+        return fail(`expected empty stdout, got: ${normalizeText(result.stdout).trim()}`);
+      }
+
+      let payload;
+      try {
+        payload = parseJson(result.stderr);
+      } catch (error) {
+        return fail(`stderr is not valid JSON: ${error.message}`);
+      }
+
+      if (payload.code !== "AUTH_MISSING") {
+        return fail(`expected AUTH_MISSING, got ${payload.code || "<missing>"}`);
+      }
+      if (typeof payload.error !== "string" || payload.error.length === 0) {
+        return fail("stderr JSON is missing a non-empty error message");
+      }
+      return pass("stderr emitted AUTH_MISSING JSON and stdout stayed empty");
+    },
+  },
+  {
+    id: "auth-login-zh-prompt",
+    title: "Chinese human-readable path is present",
+    tier: "ci",
+    command: ["auth", "login"],
+    profile: "clean",
+    env: {
+      LANG: "zh_CN.UTF-8",
+      LC_ALL: "zh_CN.UTF-8",
+    },
+    stdin: "\n",
+    validate(result) {
+      if (result.status !== 1) {
+        return fail(`expected exit 1, got ${result.status}`);
+      }
+      const stdout = normalizeText(result.stdout);
+      const stderr = normalizeText(result.stderr);
+      if (!stdout.includes("请粘贴你的 Personal Access Token")) {
+        return fail("stdout does not include the Chinese PAT prompt");
+      }
+      if (!stderr.includes("PAT cannot be empty")) {
+        return fail('stderr does not include "PAT cannot be empty"');
+      }
+      return pass("Chinese prompt appears on stdout and failure stays human-readable");
+    },
+  },
+  {
+    id: "project-list-json-live",
+    title: "project list JSON contract in live mode",
+    tier: "live",
+    command: ["project", "list", "--json"],
+    profile: "live",
+    validate(result) {
+      return validateJsonShape(result, "projects");
+    },
+  },
+  {
+    id: "wi-list-json-live",
+    title: "workitem list JSON contract in live mode",
+    tier: "live",
+    command: ["wi", "list", "--json"],
+    profile: "live",
+    validate(result) {
+      return validateJsonShape(result, "items");
+    },
+  },
+  {
+    id: "sprint-list-json-live",
+    title: "sprint list JSON contract in live mode",
+    tier: "live",
+    command: ["sprint", "list", "--json"],
+    profile: "live",
+    validate(result) {
+      return validateJsonShape(result, "sprints");
+    },
+  },
+];
+
+export function getMissingLiveEnv(env = process.env) {
+  return LIVE_ENV_VARS.filter((name) => !String(env[name] || "").trim());
+}
+
+export function getSmokeEnvironment(env = process.env) {
+  return {
+    token: String(env.YUNXIAO_SMOKE_PAT || "").trim(),
+    orgId: String(env.YUNXIAO_SMOKE_ORG_ID || "").trim(),
+    projectId: String(env.YUNXIAO_SMOKE_PROJECT_ID || "").trim(),
+    language: String(env.YUNXIAO_SMOKE_LANGUAGE || "").trim(),
+  };
+}

--- a/scripts/smoke/runner.js
+++ b/scripts/smoke/runner.js
@@ -1,0 +1,233 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { spawnSync } from "child_process";
+import { fileURLToPath } from "url";
+import { SMOKE_CASES, getMissingLiveEnv, getSmokeEnvironment } from "./matrix.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..", "..");
+
+function readPackageVersion() {
+  const raw = fs.readFileSync(path.join(repoRoot, "package.json"), "utf8");
+  return JSON.parse(raw).version;
+}
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function seedVersionCache(homeDir, packageVersion) {
+  const yunxiaoDir = path.join(homeDir, ".yunxiao");
+  ensureDir(yunxiaoDir);
+  fs.writeFileSync(
+    path.join(yunxiaoDir, "version-check-cache.json"),
+    JSON.stringify(
+      {
+        lastCheckTime: Date.now(),
+        latestVersion: packageVersion,
+        localVersion: packageVersion,
+      },
+      null,
+      2
+    ),
+    "utf8"
+  );
+}
+
+function writeSmokeConfig(homeDir, config) {
+  const yunxiaoDir = path.join(homeDir, ".yunxiao");
+  ensureDir(yunxiaoDir);
+  const payload = {
+    token: config.token,
+    orgId: config.orgId,
+    projectId: config.projectId,
+  };
+  if (config.language) {
+    payload.language = config.language;
+  }
+  fs.writeFileSync(path.join(yunxiaoDir, "config.json"), JSON.stringify(payload, null, 2), {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+}
+
+function createTempHome(prefix = "yunxiao-smoke-") {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function normalizePreview(value, limit = 240) {
+  const text = String(value || "").replace(/\r\n/g, "\n").trim();
+  if (text.length <= limit) {
+    return text;
+  }
+  return `${text.slice(0, limit)}...`;
+}
+
+function defaultReporter(_line) {
+  // no-op for tests
+}
+
+function buildChildEnv(homeDir, caseDef, liveEnv, baseEnv) {
+  return {
+    ...baseEnv,
+    HOME: homeDir,
+    USERPROFILE: homeDir,
+    YUNXIAO_PAT: "",
+    YUNXIAO_ORG_ID: "",
+    YUNXIAO_PROJECT_ID: "",
+    YUNXIAO_LANGUAGE: "",
+    ...(caseDef.env || {}),
+    ...(caseDef.profile === "live"
+      ? {
+          YUNXIAO_PAT: liveEnv.token,
+          YUNXIAO_ORG_ID: liveEnv.orgId,
+          YUNXIAO_PROJECT_ID: liveEnv.projectId,
+          ...(liveEnv.language ? { YUNXIAO_LANGUAGE: liveEnv.language } : {}),
+        }
+      : {}),
+  };
+}
+
+export function executeSmokeCase(caseDef, context) {
+  if (caseDef.tier === "live" && context.mode !== "live") {
+    return {
+      id: caseDef.id,
+      title: caseDef.title,
+      tier: caseDef.tier,
+      status: "skipped",
+      detail: "live/manual case skipped in ci mode",
+      command: `node src/index.js ${caseDef.command.join(" ")}`.trim(),
+    };
+  }
+
+  const startedAt = Date.now();
+  const homeDir = createTempHome();
+
+  try {
+    seedVersionCache(homeDir, context.packageVersion);
+
+    if (caseDef.profile === "live") {
+      writeSmokeConfig(homeDir, context.liveEnv);
+    }
+
+    const env = buildChildEnv(homeDir, caseDef, context.liveEnv, context.baseEnv);
+    const run = spawnSync(process.execPath, ["src/index.js", ...caseDef.command], {
+      cwd: context.repoRoot,
+      env,
+      encoding: "utf8",
+      input: caseDef.stdin,
+      timeout: 15000,
+    });
+
+    const elapsedMs = Date.now() - startedAt;
+
+    if (run.error) {
+      return {
+        id: caseDef.id,
+        title: caseDef.title,
+        tier: caseDef.tier,
+        status: "failed",
+        detail: `spawn failed: ${run.error.message}`,
+        command: `node src/index.js ${caseDef.command.join(" ")}`.trim(),
+        durationMs: elapsedMs,
+        exitCode: run.status,
+        stdoutPreview: normalizePreview(run.stdout),
+        stderrPreview: normalizePreview(run.stderr),
+      };
+    }
+
+    const validation = caseDef.validate(
+      {
+        status: run.status ?? 0,
+        stdout: run.stdout || "",
+        stderr: run.stderr || "",
+      },
+      context
+    );
+
+    return {
+      id: caseDef.id,
+      title: caseDef.title,
+      tier: caseDef.tier,
+      status: validation.ok ? "passed" : "failed",
+      detail: validation.detail,
+      command: `node src/index.js ${caseDef.command.join(" ")}`.trim(),
+      durationMs: elapsedMs,
+      exitCode: run.status ?? 0,
+      stdoutPreview: normalizePreview(run.stdout),
+      stderrPreview: normalizePreview(run.stderr),
+    };
+  } finally {
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+}
+
+export async function runSmokeMode(mode = "ci", options = {}) {
+  const reporter = options.reporter ?? defaultReporter;
+  const env = options.env ?? process.env;
+  const packageVersion = options.packageVersion ?? readPackageVersion();
+  const liveEnv = getSmokeEnvironment(env);
+  const missingEnv = mode === "live" ? getMissingLiveEnv(env) : [];
+
+  if (mode === "live" && missingEnv.length > 0) {
+    const summary = {
+      mode,
+      ok: false,
+      missingEnv,
+      results: [],
+      passedCount: 0,
+      failedCount: 0,
+      skippedCount: 0,
+    };
+    reporter(`Smoke ${mode}: missing required env: ${missingEnv.join(", ")}`);
+    return summary;
+  }
+
+  const context = {
+    mode,
+    repoRoot,
+    packageVersion,
+    liveEnv,
+    baseEnv: env,
+  };
+
+  const results = SMOKE_CASES.map((caseDef) => executeSmokeCase(caseDef, context));
+  const passedCount = results.filter((item) => item.status === "passed").length;
+  const failedCount = results.filter((item) => item.status === "failed").length;
+  const skippedCount = results.filter((item) => item.status === "skipped").length;
+  const ok = failedCount === 0;
+
+  for (const item of results) {
+    reporter(
+      `[${item.status.toUpperCase()}] ${item.id} (${item.tier}) - ${item.detail}`
+    );
+  }
+  reporter(
+    `Smoke ${mode} summary: ${passedCount} passed, ${failedCount} failed, ${skippedCount} skipped`
+  );
+
+  return {
+    mode,
+    ok,
+    results,
+    missingEnv,
+    passedCount,
+    failedCount,
+    skippedCount,
+  };
+}
+
+function isMain() {
+  if (!process.argv[1]) {
+    return false;
+  }
+  return path.resolve(process.argv[1]) === __filename;
+}
+
+if (isMain()) {
+  const mode = process.argv[2] === "live" ? "live" : "ci";
+  const summary = await runSmokeMode(mode, { reporter: console.log });
+  process.exit(summary.ok ? 0 : 1);
+}

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1,0 +1,66 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { LIVE_ENV_VARS, SMOKE_CASES, getMissingLiveEnv } from "../scripts/smoke/matrix.js";
+import { runSmokeMode } from "../scripts/smoke/runner.js";
+
+test("smoke matrix contains required ci and live cases", () => {
+  const ids = new Set(SMOKE_CASES.map((item) => item.id));
+
+  [
+    "version",
+    "help",
+    "auth-status-clean",
+    "project-list-json-auth-missing",
+    "auth-login-zh-prompt",
+    "project-list-json-live",
+    "wi-list-json-live",
+    "sprint-list-json-live",
+  ].forEach((id) => {
+    assert.ok(ids.has(id), `missing smoke case ${id}`);
+  });
+
+  const liveCases = SMOKE_CASES.filter((item) => item.tier === "live").map((item) => item.id);
+  assert.deepEqual(liveCases.sort(), [
+    "project-list-json-live",
+    "sprint-list-json-live",
+    "wi-list-json-live",
+  ]);
+});
+
+test("getMissingLiveEnv returns the required live env variables", () => {
+  assert.deepEqual(getMissingLiveEnv({}).sort(), [...LIVE_ENV_VARS].sort());
+  assert.deepEqual(
+    getMissingLiveEnv({
+      YUNXIAO_SMOKE_PAT: "token",
+      YUNXIAO_SMOKE_ORG_ID: "org",
+      YUNXIAO_SMOKE_PROJECT_ID: "project",
+    }),
+    []
+  );
+});
+
+test("ci smoke mode passes and skips live-only cases", async () => {
+  const summary = await runSmokeMode("ci");
+
+  assert.equal(summary.ok, true);
+  assert.equal(summary.failedCount, 0);
+
+  const skippedIds = summary.results
+    .filter((item) => item.status === "skipped")
+    .map((item) => item.id)
+    .sort();
+
+  assert.deepEqual(skippedIds, [
+    "project-list-json-live",
+    "sprint-list-json-live",
+    "wi-list-json-live",
+  ]);
+});
+
+test("live smoke mode fails fast when required env is missing", async () => {
+  const summary = await runSmokeMode("live", { env: {} });
+
+  assert.equal(summary.ok, false);
+  assert.deepEqual(summary.missingEnv.sort(), [...LIVE_ENV_VARS].sort());
+  assert.equal(summary.results.length, 0);
+});


### PR DESCRIPTION
## Summary
- add a matrix-driven real CLI smoke runner with CI-safe and live modes
- add smoke tests plus README documentation for commands, env vars, and failure criteria
- add the BMAD story artifact for 12.1 and mark sprint tracking done

## Test plan
- npm test
- npm run lint
- npm run smoke
- YUNXIAO_SMOKE_PAT=... YUNXIAO_SMOKE_ORG_ID=... YUNXIAO_SMOKE_PROJECT_ID=... npm run smoke:live