### PR TITLE
docs(bmad): add v1.2.0 handoff index tracking

### DIFF
--- a/_bmad-output/implementation-artifacts/13-3-v1-2-0-handoff-index.md
+++ b/_bmad-output/implementation-artifacts/13-3-v1-2-0-handoff-index.md
@@ -1,0 +1,151 @@
+# Story 13.3: v1.2.0 handoff index 与执行追踪工件
+
+Status: done
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Delivery Scope
+
+**Delivery Type**: documentation-only
+**User-visible Rollout Follow-up**: N/A
+**Scope Notes**: 本 Story 交付 v1.2.0 的 handoff index 与结构化 execution tracker，帮助 Scrum Master 基于当前 issue/PR/gating 事实继续派单与发布前验收；不新增或修改 CLI 用户命令行为。
+
+## Story
+
+As a scrum master,
+I want a handoff index that lists execution order, owners, review gates, and deferred scope,
+so that SM can assign work without reinterpreting the Correct Course proposal.
+
+## Acceptance Criteria
+
+1. **Given** Correct Course proposal 已批准
+   **When** 创建 handoff index
+   **Then** index 列出 P0-P5 阶段、story 执行顺序、handoff recipients、依赖、评审验收波次、发布前门禁和 v1.3.0/post-MVP 后置项
+
+2. **Given** SM 开始派单
+   **When** 查看 handoff index
+   **Then** 能识别首批 create-story 候选：11.1、12.1、12.3、13.1、13.2
+
+## Tasks / Subtasks
+
+- [x] Task 1: 创建可直接派单的 v1.2.0 handoff index (AC: #1, #2)
+  - [x] Subtask 1.1: 固化 P0-P5 阶段、story 执行顺序、handoff recipients、依赖、评审验收波次和发布前门禁
+  - [x] Subtask 1.2: 把首批 create-story 候选与后续波次顺序写成无需重新解释 Correct Course proposal 的派单索引
+  - [x] Subtask 1.3: 明确 v1.3.0 / post-MVP deferred scope，避免后续派单把后置范围误当成 v1.2.0 必做项
+
+- [x] Task 2: 产出结构化 execution tracker，记录当前 issue / PR / gating 事实 (AC: #1, #2)
+  - [x] Subtask 2.1: 汇总 HTH-201 子 issue 与当前派发状态，区分 `issue_status`、依赖状态和“实际可继续执行”的派单解释
+  - [x] Subtask 2.2: 为首批与后续波次记录 PR 链接、`pr_state`、`merged`、`merge_status` 和 `ci_status`，避免把 `PR open` 误写成已合并
+  - [x] Subtask 2.3: 为 `11.3`、`12.4` 等 gated story 标注 blocker 解析和下一位 handoff recipient
+
+- [x] Task 3: 为 handoff index / tracker 添加 guardrail 测试 (AC: #1, #2)
+  - [x] Subtask 3.1: 验证 handoff index 包含 P0-P5、首批候选、后续顺序、评审验收波次、release gate 和 deferred scope
+  - [x] Subtask 3.2: 验证 execution tracker 同时记录 issue、PR、CI、merge 状态与 dispatch interpretation
+  - [x] Subtask 3.3: 验证 open PR 明确标记 `merged: false`，且 `11.3` / `12.4` 的 gating 解释被固化
+
+- [x] Task 4: 完成 Story 工件同步关闭 (AC: #1, #2)
+  - [x] Subtask 4.1: 更新本 Story 的 Status、Tasks/Subtasks、Dev Agent Record、File List、Change Log
+  - [x] Subtask 4.2: 更新 `_bmad-output/implementation-artifacts/sprint-status.yaml` 中 Story 13.3 状态，并在 Epic 13 全部完成后关闭 epic
+  - [x] Subtask 4.3: 记录 focused test、全量单元测试、代码审查结果和残余风险
+
+## Dev Notes
+
+### 权威输入
+
+- `_bmad-output/planning-artifacts/epics.md`：Story 13.3 / FR45 的规范源，要求 handoff index 列出 P0-P5、执行顺序、handoff recipients、review gates 和 deferred scope。
+- `_bmad-output/planning-artifacts/sprint-change-proposal-2026-04-19.md`：给出首批候选和后续顺序的 canonical recommendation。
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-04-19.md`：给出 P0-P5 phase order、依赖链和 13.3 在后续波次中的位置。
+- `_bmad-output/planning-artifacts/prd.md`：给出 phase definitions、release gate、v1.2.0 out-of-scope / 后置项和 Vision (Future)。
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`：Story key 与 Epic 13 当前 repo 内状态的权威工件。
+- `_bmad-output/implementation-artifacts/story-artifact-sync-rules.md`：规定 `done` 前必须同步 Status、Tasks/Subtasks、Dev Agent Record、File List 和 sprint-status。
+- `[HTH-201]` 当前执行波次及其子 issue：用于抓取已派发/已完成/gated 的实时 issue 状态。
+- GitHub PR 快照：`#83`、`#84`、`#85`、`#86`、`#88`、`#89`、`#90`，用于记录 `pr_state`、`merged`、`merge_status` 与 `ci_status`。
+
+### 当前执行事实与解释规则
+
+- 本 Story 的输出不能只复述 planning 文档，必须叠加当前 Paperclip issue / GitHub PR 事实。
+- `issue_status`、`pr_state`、`merged`、`merge_status`、`ci_status` 是不同维度：
+  - `issue_status: done` 只表示实现 issue 已完成，不代表 PR 已合并。
+  - `pr_state: OPEN` 且 `merged: false` 必须显式保留，防止把“issue 已 done”误写成“已 merge”。
+  - `ci_status: no_checks_reported` 不是失败，但也不是“checks passed”；必须和 `all_checks_passed` 区分。
+- 对 `HTH-212` 这类状态漂移，需要记录“issue 仍是 blocked，但显式 blocker 已 done”的解释，帮助 SM 做 resume/refresh，而不是继续误判为硬阻塞。
+- 当前 worktree 基线来自 `origin/story/13-2-codeup-evidence-ledger`，并不自然包含所有并行分支的 story 文件状态；因此 handoff tracker 需要显式记录“分支外执行事实”，而不是篡改其他 story 文档来伪造当前基线。
+
+### 产物位置与结构
+
+- handoff index：`_bmad-output/implementation-artifacts/v1-2-0-handoff-index.md`
+- execution tracker：`_bmad-output/implementation-artifacts/v1-2-0-execution-tracker.yaml`
+- guardrail 测试：`test/v1-2-0-handoff-index.test.js`
+- 本 Story 保持 documentation-only，不应修改 `src/`、CLI 命令、发布脚本或外部 BMAD agent instructions。
+
+### 前序 Story Intelligence
+
+- Story 13.1 已建立 `Artifact Sync Closeout` 与冲突裁决规则；本 Story 必须沿用相同收口方式。
+- Story 13.2 已示范“文档 + 结构化测试”的落地模式：新增 implementation artifact，再用 `node:test` 对关键 marker 做 guardrail。
+- Story 11.2、12.2 已在后续波次推进，并已有 PR `#89`、`#90`；本 Story 需要把这些执行事实纳入 tracker，而不是停留在 2026-04-19 的 planning 状态。
+- Story 12.4 明确依赖 `HTH-209`、`HTH-210`、`HTH-212`、`HTH-211` 和首批 release/smoke/evidence stories；本 Story 的 tracker 必须让 12.4 能直接消费这些依赖状态。
+
+### Testing Requirements
+
+- Focused guardrail test：`node --test test/v1-2-0-handoff-index.test.js`
+- Full regression suite：`npm test`
+- 代码审查：对新增 handoff index / execution tracker / test diff 进行 adversarial review，若无必须修复项，需在 Dev Agent Record 中记录 clean review 结论。
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/epics.md#Story 13.3]
+- [Source: _bmad-output/planning-artifacts/sprint-change-proposal-2026-04-19.md#Recommended create-story order]
+- [Source: _bmad-output/planning-artifacts/implementation-readiness-report-2026-04-19.md#Dependency Analysis]
+- [Source: _bmad-output/planning-artifacts/prd.md#后续阶段顺序]
+- [Source: _bmad-output/planning-artifacts/prd.md#v1.2.0 Out of Scope / 后置]
+- [Source: _bmad-output/implementation-artifacts/story-artifact-sync-rules.md]
+- [Source: HTH-201 child issue snapshot on 2026-04-20]
+- [Source: GitHub PR snapshot #83, #84, #85, #86, #88, #89, #90 on 2026-04-20]
+
+## Artifact Sync Closeout
+
+- [x] story 文件头 `Status` 与实际状态一致
+- [x] Tasks/Subtasks 勾选与实际完成项一致
+- [x] Dev Agent Record 记录实现、测试、审查和残余风险
+- [x] File List 覆盖全部新增/修改/删除文件
+- [x] `sprint-status.yaml` 中 story key 已同步
+- [x] 若 Delivery Type 为 Foundation-only，已填写 User-visible Rollout Follow-up；本 Story 为 documentation-only，后续 rollout 不适用
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex
+
+### Debug Log References
+
+- 2026-04-20: Story 13.3 在 worktree `story/13-3-v1-2-0-handoff-index-tracking-artifacts` 中创建，基于 `origin/story/13-2-codeup-evidence-ledger` 作为执行基线。
+- 2026-04-20: 从 `_bmad-output/planning-artifacts/epics.md`、Correct Course proposal、implementation readiness report、`HTH-201` 子 issue、PR `#83/#84/#85/#86/#88/#89/#90` 收集 phase / dispatch / gating 快照。
+- 2026-04-20: 新增 `_bmad-output/implementation-artifacts/v1-2-0-handoff-index.md` 与 `_bmad-output/implementation-artifacts/v1-2-0-execution-tracker.yaml`，把 P0-P5、执行顺序、handoff recipients、review waves、release gate、deferred scope 和当前 issue/PR 状态固化。
+- 2026-04-20: 新增 `test/v1-2-0-handoff-index.test.js`，guard 住 phases、首批候选、后续顺序、dispatch interpretation 与 open-PR-not-merged 约束。
+- 2026-04-20: Focused guardrail test 与全量 `npm test` 通过；代码审查未发现必须修复项。
+- 2026-04-20: Story 13.3 与 `sprint-status.yaml` 同步为 `done`，Epic 13 因全部 stories 完成而同步关闭。
+
+### Completion Notes List
+
+- [x] 新增 `v1-2-0-handoff-index.md`，让 SM 无需重新解释 Correct Course proposal 即可看到首批候选、后续顺序、handoff recipients、review waves 与 release gate。
+- [x] 新增 `v1-2-0-execution-tracker.yaml`，结构化记录 `issue_status`、`pr_state`、`merged`、`merge_status`、`ci_status`、依赖与 dispatch interpretation。
+- [x] 明确保留“issue done but PR OPEN”与“blocked status stale after blockers resolved”这类状态，防止派单和发布决策误判。
+- [x] 明确 v1.3.0 / post-v1.2.0 / post-MVP deferred scope，避免把 Codeup 扩展、全 CLI 中文化和未来能力混入 v1.2.0 release gate。
+- [x] Focused guardrail test 已通过：`node --test test/v1-2-0-handoff-index.test.js`。
+- [x] Full unit suite 已通过：`npm test`。
+- [x] 代码审查完成：未发现必须修复项，AC1-AC2 与 handoff tracker/test 对齐。
+
+### File List
+
+- `_bmad-output/implementation-artifacts/13-3-v1-2-0-handoff-index.md` - Story 13.3 工件与执行记录。
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` - 更新 Story 13.3 与 Epic 13 状态。
+- `_bmad-output/implementation-artifacts/v1-2-0-execution-tracker.yaml` - 新增 v1.2.0 结构化执行追踪工件。
+- `_bmad-output/implementation-artifacts/v1-2-0-handoff-index.md` - 新增 v1.2.0 handoff index。
+- `test/v1-2-0-handoff-index.test.js` - 新增 handoff index / execution tracker guardrail 测试。
+
+### Change Log
+
+- 2026-04-20: 创建 Story 13.3，状态 `ready-for-dev`。
+- 2026-04-20: 完成 handoff index、execution tracker 和 guardrail test，实现状态更新为 `review`。
+- 2026-04-20: 代码审查通过，Story 13.3 与 Epic 13 状态更新为 `done`。

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-03-31
-last_updated: 2026-04-19  # v1.2.0 Correct Course planning added Epic 11-13; create-story will generate story files per issue
+last_updated: 2026-04-20  # Story 13.3 handoff index closeout; Epic 13 fully delivered in this branch baseline
 project: yunxiao-cli
 project_key: NOKEY
 tracking_system: file-system
@@ -146,8 +146,8 @@ development_status:
   epic-12-retrospective: optional
 
   # Epic 13: v1.2.0 BMAD 工件卫生与 Codeup 证据治理
-  epic-13: in-progress
+  epic-13: done
   13-1-story-artifact-sync-rules: done
   13-2-codeup-evidence-ledger: done
-  13-3-v1-2-0-handoff-index: backlog
+  13-3-v1-2-0-handoff-index: done
   epic-13-retrospective: optional

--- a/_bmad-output/implementation-artifacts/v1-2-0-execution-tracker.yaml
+++ b/_bmad-output/implementation-artifacts/v1-2-0-execution-tracker.yaml
@@ -1,0 +1,332 @@
+snapshot_date: 2026-04-20
+snapshot_note: >
+  This tracker combines planning artifacts with live Paperclip issue and GitHub PR state.
+  GitHub OPEN PRs are not merged; `issue_status: done` and `pr_state: OPEN` must be read separately.
+
+source_of_truth:
+  planning_artifacts:
+    - _bmad-output/planning-artifacts/epics.md
+    - _bmad-output/planning-artifacts/sprint-change-proposal-2026-04-19.md
+    - _bmad-output/planning-artifacts/implementation-readiness-report-2026-04-19.md
+    - _bmad-output/planning-artifacts/prd.md
+  implementation_artifacts:
+    - _bmad-output/implementation-artifacts/story-artifact-sync-rules.md
+    - _bmad-output/implementation-artifacts/sprint-status.yaml
+  execution_issues:
+    - HTH-201
+    - HTH-196
+    - HTH-197
+    - HTH-198
+    - HTH-199
+    - HTH-200
+    - HTH-209
+    - HTH-210
+    - HTH-211
+    - HTH-212
+    - HTH-213
+  github_prs:
+    - 83
+    - 84
+    - 85
+    - 86
+    - 88
+    - 89
+    - 90
+
+dispatch_interpretation:
+  issue_done_pr_open: "Issue complete in Paperclip, but PR is still OPEN and merged=false."
+  blocked_status_stale: "Issue still says blocked, but all explicit blockers are already done; Scrum Master should refresh/resume."
+  blocked_waiting_dependencies: "Issue cannot proceed yet because one or more blocker stories are not done."
+  in_progress_no_pr_yet: "Work is active and the branch does not have a published PR yet."
+  no_pr_yet: "No GitHub PR has been created for this story yet."
+
+phases:
+  P0:
+    status: done
+    goal: PRD / epics / change proposal / sprint status alignment
+    handoff_recipient: Scrum Master
+  P1:
+    status: in_progress
+    goal: create-story preparation and dispatch sequencing
+    handoff_recipient: Developer
+  P2:
+    status: in_progress
+    goal: development wave 1
+    handoff_recipient: Scrum Master
+  P3:
+    status: in_progress
+    goal: development wave 2
+    handoff_recipient: Scrum Master
+  P4:
+    status: pending
+    goal: review and acceptance waves
+    handoff_recipient: Reviewer / Test Architect
+  P5:
+    status: pending
+    goal: pre-release gate and GO/NO-GO
+    handoff_recipient: Scrum Master / Release Owner
+
+execution_order:
+  - order: 1
+    phase: P2
+    story_id: "13.1"
+    story_key: 13-1-story-artifact-sync-rules
+    title: Story 工件状态同步规则与 foundation-only 标记
+    paperclip_issue: HTH-196
+    issue_status: done
+    dependencies: []
+    next_handoff: Scrum Master
+    github_pr:
+      created: true
+      number: 83
+      url: https://github.com/kongsiyu/yunxiao-cli/pull/83
+      pr_state: OPEN
+      merged: false
+      merge_status: CLEAN
+      ci_status: all_checks_passed
+    combined_state: issue_done_pr_open
+
+  - order: 2
+    phase: P2
+    story_id: "11.1"
+    story_key: 11-1-i18n-audit-rollout-scope
+    title: i18n 缺口审计与 rollout 范围锁定
+    paperclip_issue: HTH-197
+    issue_status: done
+    dependencies: []
+    next_handoff: Scrum Master
+    github_pr:
+      created: true
+      number: 88
+      url: https://github.com/kongsiyu/yunxiao-cli/pull/88
+      pr_state: OPEN
+      merged: false
+      merge_status: CLEAN
+      ci_status: no_checks_reported
+    combined_state: issue_done_pr_open
+
+  - order: 3
+    phase: P2
+    story_id: "12.3"
+    story_key: 12-3-release-checklist-template
+    title: Release checklist 模板化
+    paperclip_issue: HTH-198
+    issue_status: done
+    dependencies: []
+    next_handoff: Scrum Master
+    github_pr:
+      created: true
+      number: 84
+      url: https://github.com/kongsiyu/yunxiao-cli/pull/84
+      pr_state: OPEN
+      merged: false
+      merge_status: CLEAN
+      ci_status: all_checks_passed
+    combined_state: issue_done_pr_open
+
+  - order: 4
+    phase: P2
+    story_id: "12.1"
+    story_key: 12-1-real-cli-smoke-matrix
+    title: 真实 CLI smoke matrix 与执行入口
+    paperclip_issue: HTH-199
+    issue_status: done
+    dependencies: []
+    next_handoff: Scrum Master
+    github_pr:
+      created: true
+      number: 85
+      url: https://github.com/kongsiyu/yunxiao-cli/pull/85
+      pr_state: OPEN
+      merged: false
+      merge_status: CLEAN
+      ci_status: all_checks_passed
+    combined_state: issue_done_pr_open
+
+  - order: 5
+    phase: P2
+    story_id: "13.2"
+    story_key: 13-2-codeup-evidence-ledger
+    title: Codeup evidence ledger
+    paperclip_issue: HTH-200
+    issue_status: done
+    dependencies:
+      - 13.1
+    next_handoff: Scrum Master
+    github_pr:
+      created: true
+      number: 86
+      url: https://github.com/kongsiyu/yunxiao-cli/pull/86
+      pr_state: OPEN
+      merged: false
+      merge_status: CLEAN
+      ci_status: no_checks_reported
+    combined_state: issue_done_pr_open
+
+  - order: 6
+    phase: P3
+    story_id: "11.2"
+    story_key: 11-2-high-frequency-i18n-rollout
+    title: 高频命令人类可读输出中文化 rollout
+    paperclip_issue: HTH-209
+    issue_status: done
+    dependencies:
+      - 11.1
+    next_handoff: Scrum Master
+    github_pr:
+      created: true
+      number: 89
+      url: https://github.com/kongsiyu/yunxiao-cli/pull/89
+      pr_state: OPEN
+      merged: false
+      merge_status: CLEAN
+      ci_status: no_checks_reported
+    combined_state: issue_done_pr_open
+
+  - order: 7
+    phase: P3
+    story_id: "12.2"
+    story_key: 12-2-json-stdio-error-contract-tests
+    title: JSON/stdout/stderr/error-code 契约回归测试补强
+    paperclip_issue: HTH-210
+    issue_status: done
+    dependencies:
+      - 12.1
+    next_handoff: Scrum Master
+    github_pr:
+      created: true
+      number: 90
+      url: https://github.com/kongsiyu/yunxiao-cli/pull/90
+      pr_state: OPEN
+      merged: false
+      merge_status: CLEAN
+      ci_status: no_checks_reported
+    combined_state: issue_done_pr_open
+
+  - order: 8
+    phase: P3
+    story_id: "11.3"
+    story_key: 11-3-readme-skill-i18n-boundaries
+    title: README / SKILL 边界补充
+    paperclip_issue: HTH-212
+    issue_status: blocked
+    dependencies:
+      - 11.1
+      - 11.2
+    blocker_snapshot:
+      - issue: HTH-209
+        status: done
+    next_handoff: Scrum Master -> Developer
+    github_pr:
+      created: false
+      pr_state: not_created
+      merged: false
+    combined_state: blocked_status_stale
+
+  - order: 9
+    phase: P3
+    story_id: "13.3"
+    story_key: 13-3-v1-2-0-handoff-index
+    title: v1.2.0 handoff index 与执行追踪工件
+    paperclip_issue: HTH-211
+    issue_status: in_progress
+    dependencies:
+      - HTH-201 execution snapshot
+      - PR 83/84/85/86/88/89/90 state snapshot
+    next_handoff: Scrum Master
+    github_pr:
+      created: false
+      pr_state: not_created
+      merged: false
+    combined_state: in_progress_no_pr_yet
+
+  - order: 10
+    phase: P5
+    story_id: "12.4"
+    story_key: 12-4-release-evidence-summary
+    title: v1.2.0 发布前验收与 release evidence 汇总
+    paperclip_issue: HTH-213
+    issue_status: blocked
+    dependencies:
+      - 11.2
+      - 12.2
+      - 11.3
+      - 13.3
+      - 12.3
+      - 12.1
+      - 13.2
+    blocker_snapshot:
+      - issue: HTH-209
+        status: done
+      - issue: HTH-210
+        status: done
+      - issue: HTH-212
+        status: blocked
+      - issue: HTH-211
+        status: in_progress
+    next_handoff: Scrum Master -> Developer -> Reviewer / Test Architect
+    github_pr:
+      created: false
+      pr_state: not_created
+      merged: false
+    combined_state: blocked_waiting_dependencies
+
+review_acceptance_waves:
+  - wave_id: wave-a-baseline-inputs
+    stories:
+      - 13.1
+      - 11.1
+      - 12.3
+      - 12.1
+      - 13.2
+    status: awaiting_merge_visibility
+    gate: artifact rules, i18n scope, release checklist, smoke matrix, Codeup evidence ledger all available and traceable
+
+  - wave_id: wave-b-rollout-contract-handoff
+    stories:
+      - 11.2
+      - 12.2
+      - 11.3
+      - 13.3
+    status: in_progress
+    gate: zh rollout, JSON contract regression guardrails, docs boundary, canonical handoff tracker all aligned
+
+  - wave_id: wave-c-release-go-no-go
+    stories:
+      - 12.4
+    status: blocked
+    gate: release evidence summary classifies blockers vs residual risks and confirms gate readiness
+
+release_gate:
+  owner: Scrum Master / Release Owner
+  summary_story: 12.4
+  blocked_by:
+    - HTH-212
+    - HTH-211
+    - unmerged implementation PRs
+  pre_release_checks:
+    - npm test
+    - critical CLI smoke evidence
+    - npm pack --dry-run
+    - runtime version / package.json / git tag alignment
+    - release note readiness
+    - publish workflow or pipeline status
+    - PR / commit traceability
+    - blocker vs residual risk classification
+
+deferred_scope:
+  v1_3_0_candidates:
+    - Codeup MR merge
+    - Codeup MR comment
+    - Codeup MR approval
+    - Codeup MR diff
+    - Codeup MR commits
+    - Codeup MR discussions
+  post_v1_2_0_backlog:
+    - Full CLI localization beyond the high-frequency scope
+    - Direct BMAD agent instruction edits outside repo-local workflows/artifacts
+  post_mvp_future:
+    - Shell completion
+    - Interactive TUI mode
+    - Multi-organization / multi-project fast switching
+    - Broader Yunxiao module expansion beyond the current evidence baseline

--- a/_bmad-output/implementation-artifacts/v1-2-0-handoff-index.md
+++ b/_bmad-output/implementation-artifacts/v1-2-0-handoff-index.md
@@ -1,0 +1,87 @@
+# v1.2.0 Handoff Index
+
+Snapshot date: 2026-04-20
+Snapshot note: This index combines planning artifacts with live Paperclip issue and GitHub PR state. `issue_status: done` never implies PR merged; `pr_state: OPEN` with `merged: false` is still unmerged work.
+
+## Dispatch Rules
+
+1. Use the execution order below as the canonical dispatch order. Do not reinterpret the Correct Course proposal per heartbeat.
+2. Treat `issue_status`, `pr_state`, `merged`, `merge_status`, and `ci_status` as separate facts.
+3. If an issue is still `blocked` but all explicit blockers are already `done`, treat it as a dispatch-refresh action, not as a hard blocker.
+4. Do not start `12.4` until `11.3` and `13.3` are both complete and their handoff evidence is available.
+
+## Phase Map
+
+| Phase | Goal | Current snapshot | Handoff recipient |
+|---|---|---|---|
+| P0 | PRD / epics / change proposal / sprint status 对齐 | Done. PRD、epics、sprint change proposal、readiness report 已形成 v1.2.0 基线。 | BMAD Planner -> Scrum Master |
+| P1 | Story 准备与派单 | Active. 首批和后续 wave issue 已创建；`11.3` 需要 unblock refresh，`12.4` 继续等待最终 release gate 条件。 | Scrum Master -> Developer |
+| P2 | 开发波次 1 | First batch issues `HTH-196/197/198/199/200` 都已 `done`，但 PR `#83/#88/#84/#85/#86` 仍为 `OPEN (not merged)`。 | Developer -> Scrum Master |
+| P3 | 开发波次 2 | `HTH-209`、`HTH-210` 已 `done` 且 PR `#89/#90` 为 `OPEN (not merged)`；`HTH-211` 正在产出 handoff/tracker；`HTH-212` 需要 unblock refresh。 | Developer -> Scrum Master |
+| P4 | 评审验收波次 | 尚未整体收口。需要在 `11.3` 与 `13.3` 完成后统一确认 docs boundary、machine contract、story closeout 和 release evidence 输入。 | Reviewer / Test Architect -> Scrum Master |
+| P5 | 发布前门禁 | 尚未启动。`12.4` 仍 blocked，且多个实施 PR 尚未合并。 | Scrum Master / Release Owner |
+
+## First Batch Create-Story Candidates
+
+| Order | Story | Dispatch issue | Dependency | Current snapshot | Next handoff |
+|---|---|---|---|---|---|
+| 1 | `13.1` Story 工件状态同步规则与 foundation-only 标记 | `HTH-196` | None | Issue `done`; PR `#83` is `OPEN (not merged)`; `merge_status=CLEAN`; `ci_status=all_checks_passed`. | Scrum Master |
+| 2 | `11.1` i18n 缺口审计与 rollout 范围锁定 | `HTH-197` | None | Issue `done`; PR `#88` is `OPEN (not merged)`; `merge_status=CLEAN`; `ci_status=no_checks_reported`. | Scrum Master |
+| 3 | `12.3` Release checklist 模板化 | `HTH-198` | None | Issue `done`; PR `#84` is `OPEN (not merged)`; `merge_status=CLEAN`; `ci_status=all_checks_passed`. | Scrum Master |
+| 4 | `12.1` 真实 CLI smoke matrix 与执行入口 | `HTH-199` | None | Issue `done`; PR `#85` is `OPEN (not merged)`; `merge_status=CLEAN`; `ci_status=all_checks_passed`. | Scrum Master |
+| 5 | `13.2` Codeup evidence ledger | `HTH-200` | Uses `13.1` artifact-rules branch baseline | Issue `done`; PR `#86` is `OPEN (not merged)`; `merge_status=CLEAN`; `ci_status=no_checks_reported`. | Scrum Master |
+
+## Remaining Execution Order
+
+| Order | Story | Dispatch issue | Dependency | Current snapshot | Next handoff |
+|---|---|---|---|---|---|
+| 6 | `11.2` 高频命令人类可读输出中文化 rollout | `HTH-209` | `11.1` | Issue `done`; PR `#89` is `OPEN (not merged)`; `merge_status=CLEAN`; `ci_status=no_checks_reported`. | Scrum Master |
+| 7 | `12.2` JSON/stdout/stderr/error-code 契约回归测试补强 | `HTH-210` | `12.1` | Issue `done`; PR `#90` is `OPEN (not merged)`; `merge_status=CLEAN`; `ci_status=no_checks_reported`. | Scrum Master |
+| 8 | `11.3` README / SKILL 边界补充 | `HTH-212` | `11.2` + `11.1` | Issue still `blocked`, but explicit blocker `HTH-209` is already `done`; no PR yet. Interpret this as `blocked_status_stale` and resume/create-story refresh instead of treating it as a hard stop. | Scrum Master -> Developer |
+| 9 | `13.3` v1.2.0 handoff index 与执行追踪工件 | `HTH-211` | Needs current `HTH-201` + PR snapshot, not merged-first assumptions | This Story produces the canonical handoff snapshot and execution tracker. Before Step 8 push/PR, treat it as current implementation work. | Developer -> Scrum Master |
+| 10 | `12.4` v1.2.0 发布前验收与 release evidence 汇总 | `HTH-213` | `11.2`, `12.2`, `11.3`, `13.3`, plus first-batch release/smoke/evidence inputs | Issue is `blocked`; blockers `HTH-209` and `HTH-210` are already `done`, but `HTH-212` remains stale-blocked and `HTH-211` must complete first. No PR yet. | Scrum Master -> Developer -> Reviewer / Test Architect |
+
+## Review / Acceptance Waves
+
+| Wave | Stories | What must be accepted together | Current snapshot |
+|---|---|---|---|
+| Wave A: baseline-input acceptance | `13.1`, `11.1`, `12.3`, `12.1`, `13.2` | Story artifact sync rules, i18n scope lock, release checklist, smoke matrix, Codeup evidence ledger all exist and stay traceable. | All issues are `done`; every related PR is still `OPEN (not merged)`. |
+| Wave B: rollout-contract-handoff acceptance | `11.2`, `12.2`, `11.3`, `13.3` | Human-readable zh rollout, JSON contract regressions, README/SKILL boundary, and canonical handoff tracker line up. | `11.2` + `12.2` issues are `done` with open PRs; `11.3` needs unblock refresh; `13.3` is the current story. |
+| Wave C: release GO/NO-GO acceptance | `12.4` | Release evidence summary must classify blockers vs residual risks and confirm gate readiness. | Not started; still blocked by `11.3`, `13.3`, and unmerged evidence PRs. |
+
+## Release Gate Before `12.4`
+
+The release gate remains owned by `12.4`. Before that story can close, the handoff index expects these checks to be assembled in one place:
+
+- `npm test`
+- Critical CLI smoke evidence from the v1.2.0 matrix
+- `npm pack --dry-run`
+- runtime version / `package.json` version / git tag alignment
+- release note readiness
+- publish workflow / pipeline status
+- PR / commit traceability
+- explicit classification of release blockers vs non-blocking residual risks
+
+## Deferred Scope
+
+### v1.3.0 Candidate Scope
+
+- Codeup MR merge/comment/approval/diff/commits/discussions, gated by the evidence ledger and any required spike/live verification
+
+### Post-v1.2.0 Backlog
+
+- Full-CLI localization beyond the scoped high-frequency commands
+- Direct edits to BMAD agent instructions; v1.2.0 only fixes project-local workflows/artifacts
+
+### Post-MVP / Future
+
+- Shell completion
+- Interactive TUI mode
+- Multi-organization / multi-project fast switching
+- Broader Yunxiao module expansion beyond the currently evidenced scope
+
+## Data Provenance
+
+- Planning baseline: `epics.md`, `sprint-change-proposal-2026-04-19.md`, `implementation-readiness-report-2026-04-19.md`, `prd.md`
+- Execution baseline: `HTH-201` child issues `HTH-196` through `HTH-213`
+- PR snapshot used for status columns: `#83`, `#84`, `#85`, `#86`, `#88`, `#89`, `#90`

--- a/test/v1-2-0-handoff-index.test.js
+++ b/test/v1-2-0-handoff-index.test.js
@@ -1,0 +1,113 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'fs';
+
+function read(path) {
+  return readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+}
+
+describe('v1.2.0 handoff index', () => {
+  test('covers phase map, first batch, later order, review waves, release gate, and deferred scope', () => {
+    const index = read('_bmad-output/implementation-artifacts/v1-2-0-handoff-index.md');
+
+    for (const required of [
+      'P0',
+      'P1',
+      'P2',
+      'P3',
+      'P4',
+      'P5',
+      '13.1',
+      '11.1',
+      '12.3',
+      '12.1',
+      '13.2',
+      '11.2',
+      '12.2',
+      '11.3',
+      '13.3',
+      '12.4',
+      'Wave A',
+      'Wave B',
+      'Wave C',
+      'Release Gate Before `12.4`',
+      'Codeup MR merge/comment/approval/diff/commits/discussions',
+      'Full-CLI localization beyond the scoped high-frequency commands',
+      'Shell completion',
+      'Interactive TUI mode',
+    ]) {
+      assert.match(index, new RegExp(required.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    }
+  });
+
+  test('keeps issue completion separate from open PR state and highlights stale blockers', () => {
+    const index = read('_bmad-output/implementation-artifacts/v1-2-0-handoff-index.md');
+
+    for (const required of [
+      'PR `#83` is `OPEN (not merged)`',
+      'PR `#84` is `OPEN (not merged)`',
+      'PR `#85` is `OPEN (not merged)`',
+      'PR `#86` is `OPEN (not merged)`',
+      'PR `#88` is `OPEN (not merged)`',
+      'PR `#89` is `OPEN (not merged)`',
+      'PR `#90` is `OPEN (not merged)`',
+      'blocked_status_stale',
+      'HTH-212',
+      'HTH-213',
+      'ci_status=no_checks_reported',
+      'ci_status=all_checks_passed',
+    ]) {
+      assert.match(index, new RegExp(required.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    }
+  });
+});
+
+describe('v1.2.0 execution tracker', () => {
+  test('records issue, PR, merge, CI, and dispatch interpretation fields', () => {
+    const tracker = read('_bmad-output/implementation-artifacts/v1-2-0-execution-tracker.yaml');
+
+    for (const required of [
+      'issue_done_pr_open',
+      'blocked_status_stale',
+      'blocked_waiting_dependencies',
+      'in_progress_no_pr_yet',
+      'paperclip_issue: HTH-196',
+      'paperclip_issue: HTH-209',
+      'paperclip_issue: HTH-212',
+      'paperclip_issue: HTH-213',
+      'pr_state: OPEN',
+      'merged: false',
+      'merge_status: CLEAN',
+      'ci_status: all_checks_passed',
+      'ci_status: no_checks_reported',
+      'pr_state: not_created',
+      'next_handoff: Scrum Master -> Developer',
+    ]) {
+      assert.match(tracker, new RegExp(required.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    }
+  });
+
+  test('captures review waves, release gate inputs, and deferred scope buckets', () => {
+    const tracker = read('_bmad-output/implementation-artifacts/v1-2-0-execution-tracker.yaml');
+
+    for (const required of [
+      'wave-a-baseline-inputs',
+      'wave-b-rollout-contract-handoff',
+      'wave-c-release-go-no-go',
+      'summary_story: 12.4',
+      'npm test',
+      'critical CLI smoke evidence',
+      'npm pack --dry-run',
+      'Codeup MR merge',
+      'Codeup MR comment',
+      'Codeup MR approval',
+      'Codeup MR diff',
+      'Codeup MR commits',
+      'Codeup MR discussions',
+      'Full CLI localization beyond the high-frequency scope',
+      'Interactive TUI mode',
+    ]) {
+      assert.match(tracker, new RegExp(required.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a canonical v1.2.0 handoff index for SM dispatch, review waves, release gates, and deferred scope
- add a structured execution tracker that records Paperclip issue state, PR state, merge state, CI state, and dispatch interpretation
- add guardrail tests and sync Story 13.3 / Epic 13 sprint status closeout

## Test plan
- node --test test/v1-2-0-handoff-index.test.js
- npm test
