### PR TITLE
docs(release): add v1.2.0 release evidence summary

### DIFF
--- a/_bmad-output/implementation-artifacts/12-4-release-evidence-summary.md
+++ b/_bmad-output/implementation-artifacts/12-4-release-evidence-summary.md
@@ -1,0 +1,139 @@
+# Story 12.4: v1.2.0 发布前验收与 release evidence 汇总
+
+Status: done
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a reviewer,
+I want a single release evidence summary before v1.2.0 goes out,
+so that GO/NO-GO is based on explicit evidence instead of scattered comments.
+
+## Acceptance Criteria
+
+1. **Given** Epic 11-13 的 v1.2.0 stories 已完成, **when** 执行发布前验收, **then** 汇总测试、smoke、pack dry-run、version/tag、release note、已知残余风险和后置项.
+2. **Given** 存在残余风险, **when** Reviewer 给出结论, **then** 明确区分 release blocker 与 non-blocking residual risk.
+3. **Given** 前置 PR 尚未合并, **when** 生成 release evidence, **then** 每个未合并 PR 必须标记为 release blocker 或明确说明为什么不是 blocker.
+4. **Given** Reviewer / Scrum Master 做 GO/NO-GO 判断, **when** 阅读 release evidence, **then** 可在一个工件中看到本地验证、CI/PR 状态、commit/tag 可追溯性、release note 状态、后置项和明确结论.
+
+## Tasks / Subtasks
+
+- [x] Task 1: 汇总 release gate 输入事实 (AC: #1, #3, #4)
+  - [x] Subtask 1.1: 记录当前 runtime/package/tag 版本、当前分支 HEAD、目标基线和 release note/checklist 状态.
+  - [x] Subtask 1.2: 汇总 PR #83/#84/#85/#86/#89/#90/#91/#92 的 head/base、merge 状态、CI 状态和 release gate 分类.
+  - [x] Subtask 1.3: 汇总 Story 11.2、11.3、12.1、12.2、12.3、13.1、13.2、13.3 的交付证据位置和可消费性.
+
+- [x] Task 2: 创建单一 release evidence summary 工件 (AC: #1, #2, #3, #4)
+  - [x] Subtask 2.1: 新增 `_bmad-output/implementation-artifacts/v1-2-0-release-evidence-summary.md`.
+  - [x] Subtask 2.2: 明确 GO/NO-GO 结论；若任何 release blocker 存在，结论必须为 `NO-GO`.
+  - [x] Subtask 2.3: 分离 `Release Blockers`、`Non-blocking Residual Risks`、`Post-release Follow-ups`.
+  - [x] Subtask 2.4: 覆盖测试、smoke、pack dry-run、version/tag、release note、publish workflow、PR/commit traceability 和 reviewer handoff.
+
+- [x] Task 3: 增加 guardrail 测试保护 evidence 结构 (AC: #1, #2, #3, #4)
+  - [x] Subtask 3.1: 新增 `test/v1-2-0-release-evidence-summary.test.js`.
+  - [x] Subtask 3.2: 测试 evidence 包含 GO/NO-GO、release blockers、non-blocking residual risks、post-release follow-ups、version/tag、test/smoke/pack、release note、PR traceability.
+  - [x] Subtask 3.3: 测试未合并 prerequisite PR 被显式分类，且存在 blocker 时结论保持 `NO-GO`.
+
+- [x] Task 4: 完成验证、代码审查和 BMAD 工件同步 (AC: #1, #2, #3, #4)
+  - [x] Subtask 4.1: 运行 focused guardrail test 与 `npm test`.
+  - [x] Subtask 4.2: 执行 BMAD code review，修复必须修复项.
+  - [x] Subtask 4.3: 更新本 Story 的 Dev Agent Record、File List、Change Log 与 `sprint-status.yaml`.
+
+## Dev Notes
+
+### 权威输入
+
+- `_bmad-output/planning-artifacts/epics.md`: Story 12.4 / FR42 / FR45, 要求发布前单一 evidence summary.
+- `_bmad-output/planning-artifacts/implementation-readiness-report-2026-04-19.md`: v1.2.0 P0-P5 phase order、release gate 和依赖关系.
+- `_bmad-output/planning-artifacts/sprint-change-proposal-2026-04-19.md`: 首批候选和后续派单顺序.
+- `_bmad-output/planning-artifacts/prd.md`: v1.2.0 scope、out-of-scope、release gate 和 AI workflow 契约稳定要求.
+- HTH-213 issue description: 前置 PR 未合并时必须在 release evidence 中标记为 release blocker 或说明非 blocker 原因.
+- PR #84 / Story 12.3: release checklist template 是 release evidence 的输入，但当前未合并到本基线.
+- PR #85 / Story 12.1: smoke matrix 和 `npm run smoke` 是 release evidence 输入，但当前未合并到本基线.
+- PR #90 / Story 12.2: JSON/stdout/stderr/error-code contract regression 是 release evidence 输入，但当前未合并到本基线.
+- PR #91 / Story 13.3: handoff index / execution tracker 是 release evidence 输入，但当前未合并到本基线.
+
+### 当前 GitHub / Release Gate 事实
+
+- 当前执行分支基于 `origin/docs/bmad-owned-repo-workflow-templates`，输入基线 HEAD `89d60a8`.
+- `origin/master` HEAD `dcc353a` 已打 tag `v1.1.0`; 当前 `package.json` 版本仍为 `1.1.0`; 尚无 `v1.2.0` tag.
+- PR #83 (`story/13-1-story-artifact-sync-rules` -> `master`) OPEN, CLEAN, checks pass on Node 18/20/22, not merged.
+- PR #84 (`story/12-3-release-checklist-template` -> `master`) OPEN, CLEAN, checks pass on Node 18/20/22, not merged.
+- PR #85 (`story/12-1-real-cli-smoke-matrix` -> `master`) OPEN, CLEAN, checks pass on Node 18/20/22, not merged.
+- PR #86 (`story/13-2-codeup-evidence-ledger` -> `story/13-1-story-artifact-sync-rules`) OPEN, CLEAN, no checks reported, not merged.
+- PR #89 (`story/11-2-high-frequency-output-zh-rollout` -> `story/11-1-i18n-audit-rollout-scope`) OPEN, CLEAN, no checks reported, not merged.
+- PR #90 (`story/12-2-json-io-contract-regression-tests` -> `story/12-1-real-cli-smoke-matrix`) OPEN, CLEAN, no checks reported, not merged.
+- PR #91 (`story/13-3-v1-2-0-handoff-index-tracking-artifacts` -> `story/13-2-codeup-evidence-ledger`) OPEN, CLEAN, no checks reported, not merged.
+- PR #92 (`story/11-3-readme-skill-boundary-clarifications` -> `story/11-2-high-frequency-output-zh-rollout`) OPEN, CLEAN, no checks reported, not merged.
+
+### Implementation Boundaries
+
+- 本 Story 是 release evidence / documentation + guardrail test，不修改 CLI runtime 行为.
+- 不复制未合并 PR 的实现文件到本分支；未合并 prerequisite 只能作为 release blocker 或 residual risk 在 evidence 中分类.
+- 不声称 v1.2.0 release ready；只要 prerequisite PR 未合并、`v1.2.0` tag 缺失或 release note/checklist 未落入 release branch，结论必须为 `NO-GO`.
+- Evidence 必须可供 Reviewer/SM 直接判断，不依赖读 issue comments.
+- Evidence 中的命令执行结果必须区分 `local verification on current evidence branch` 与 `dependency branch evidence`.
+
+### Testing Requirements
+
+- 新增 focused test 直接读取 `_bmad-output/implementation-artifacts/v1-2-0-release-evidence-summary.md`.
+- Required commands:
+  - `node --test test/v1-2-0-release-evidence-summary.test.js`
+  - `npm test`
+- 若当前基线没有 `npm run smoke` 或 release checklist template 文件，不要伪造通过；在 evidence 中记录为 blocker / blocked by open PR.
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/epics.md#Story 12.4]
+- [Source: _bmad-output/planning-artifacts/implementation-readiness-report-2026-04-19.md#Recommended Next Steps]
+- [Source: _bmad-output/planning-artifacts/sprint-change-proposal-2026-04-19.md#Recommended create-story order]
+- [Source: _bmad-output/planning-artifacts/prd.md#v1.2.0 Correct Course Scope]
+- [Source: _bmad-output/implementation-artifacts/sprint-status.yaml]
+- [Source: GitHub PR snapshot #83/#84/#85/#86/#89/#90/#91/#92 on 2026-04-20]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex
+
+### Debug Log References
+
+- 2026-04-20: Story 12.4 created in worktree `story/12-4-v1-2-0-release-evidence-summary`; worktree corrected to `origin/docs/bmad-owned-repo-workflow-templates` because `origin/master` lacked the required April 19 planning inputs.
+- 2026-04-20: Started dev-story implementation; sprint status moved to `in-progress`.
+- 2026-04-20: Red focused test failed on missing `v1-2-0-release-evidence-summary.md`, then passed after creating the release evidence summary.
+- 2026-04-20: Initial full `npm test` failed because the new worktree had no installed dependencies (`axios`, `commander`, `chalk` missing); ran `npm ci`, then full `npm test` passed.
+- 2026-04-20: Story moved to `review`; sprint status moved to `review` after focused/full validation passed.
+- 2026-04-20: BMAD code review found one traceability wording issue: `Current evidence HEAD 89d60a8` would become stale after commit; patched to `Evidence input baseline HEAD 89d60a8`.
+- 2026-04-20: Post-review focused guardrail and full `npm test` passed; story and sprint status moved to `done`.
+
+### Completion Notes List
+
+- Story created by BMAD create-story workflow with PR/CI facts loaded for release evidence implementation.
+- Started implementation after loading full Story 12.4 context and release gate inputs.
+- Created `_bmad-output/implementation-artifacts/v1-2-0-release-evidence-summary.md` with a single `NO-GO` release decision, blocker table, residual risk table, post-release follow-ups, verification evidence, version/tag/package evidence, release note/publish workflow evidence, PR/commit traceability, and reviewer handoff.
+- Classified all unmerged prerequisite PRs #83/#84/#85/#86/#89/#90/#91/#92 as release blockers; no prerequisite PR is treated as non-blocking while unmerged.
+- Added `test/v1-2-0-release-evidence-summary.test.js` to guard required evidence sections and prevent accidental `GO` while blockers exist.
+- Verification completed: focused guardrail test passed 4/4, `npm test` passed 299/299 after `npm ci`, and `npm run lint` printed runtime version `1.1.0`.
+- `npm ci` reported 2 moderate audit findings in existing dependencies; no dependency changes were made because this Story is release evidence only.
+- Story moved to `review` after all implementation tasks except code review were completed.
+- BMAD code review completed with one internal patch to keep HEAD traceability accurate after this story commit.
+- Post-review validation passed: `node --test test/v1-2-0-release-evidence-summary.test.js` passed 4/4 and `npm test` passed 299/299.
+- Story and `sprint-status.yaml` moved to `done`.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/12-4-release-evidence-summary.md`
+- `_bmad-output/implementation-artifacts/v1-2-0-release-evidence-summary.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `test/v1-2-0-release-evidence-summary.test.js`
+
+### Change Log
+
+- 2026-04-20: Created Story 12.4 and set status to `ready-for-dev`.
+- 2026-04-20: Started Story 12.4 implementation and set status to `in-progress`.
+- 2026-04-20: Implemented release evidence summary and guardrail tests; focused/full validations passed.
+- 2026-04-20: Moved Story 12.4 to `review` for BMAD code review.
+- 2026-04-20: Patched code review finding for evidence baseline HEAD wording.
+- 2026-04-20: BMAD code review complete; Story 12.4 and sprint status updated to `done`.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-03-31
-last_updated: 2026-04-19  # v1.2.0 Correct Course planning added Epic 11-13; create-story will generate story files per issue
+last_updated: 2026-04-20  # Story 12.4 release evidence summary completed
 project: yunxiao-cli
 project_key: NOKEY
 tracking_system: file-system
@@ -142,7 +142,7 @@ development_status:
   12-1-real-cli-smoke-matrix: backlog
   12-2-json-stdio-error-contract-tests: backlog
   12-3-release-checklist-template: backlog
-  12-4-release-evidence-summary: backlog
+  12-4-release-evidence-summary: done
   epic-12-retrospective: optional
 
   # Epic 13: v1.2.0 BMAD 工件卫生与 Codeup 证据治理

--- a/_bmad-output/implementation-artifacts/v1-2-0-release-evidence-summary.md
+++ b/_bmad-output/implementation-artifacts/v1-2-0-release-evidence-summary.md
@@ -1,0 +1,137 @@
+# v1.2.0 Release Evidence Summary
+
+Generated: 2026-04-20
+Story: 12.4 / HTH-213
+Evidence branch: `story/12-4-v1-2-0-release-evidence-summary`
+Evidence baseline: `origin/docs/bmad-owned-repo-workflow-templates`
+Evidence input baseline HEAD `89d60a8` (`docs: add v1.2.0 planning artifacts`)
+
+## GO/NO-GO Decision
+
+**Decision**: `NO-GO`
+
+Open release blockers exist. v1.2.0 must not be tagged, published, or handed to the publish workflow until the blocker table below is cleared and this evidence is regenerated against the final release branch.
+
+Primary reasons:
+
+- Required prerequisite PRs for v1.2.0 remain open and unmerged.
+- The current branch still reports `package.json version` `1.1.0`; no `v1.2.0` git tag exists.
+- Release checklist, smoke runner, JSON contract regression, i18n rollout, docs boundary, evidence ledger, and handoff tracker are not all merged into a single release branch.
+- `npm run smoke` is a required release gate, but it is unavailable on this evidence baseline until PR #85 is merged.
+- `npm pack --dry-run` was not executed as a final release proof because the target v1.2.0 release branch and package version do not exist yet.
+
+## Release Blockers
+
+| ID | Evidence | Classification | Required resolution |
+| --- | --- | --- | --- |
+| B1 | `package.json version` is `1.1.0`; runtime version also resolves from `package.json`; latest tag is `v1.1.0`; no `v1.2.0` git tag exists. | Release blocker | Update final release branch to `1.2.0`, verify runtime version, and create/push `v1.2.0` only after all release gates pass. |
+| B2 | #83 `docs(bmad): add story artifact sync rules` is OPEN, CLEAN, unmerged; checks pass on Node 18/20/22. | Release blocker | Merge or deliberately exclude with reviewer approval; if excluded, regenerate evidence explaining why FR43/FR45 sync rules are not required for v1.2.0. |
+| B3 | #84 `docs(release): add release checklist template` is OPEN, CLEAN, unmerged; checks pass on Node 18/20/22. | Release blocker | Merge before release so checklist evidence is part of the release branch. |
+| B4 | #85 `test(smoke): add real CLI smoke matrix runner` is OPEN, CLEAN, unmerged; checks pass on Node 18/20/22. | Release blocker | Merge before release so `npm run smoke` and live/manual smoke instructions are available. |
+| B5 | #86 `docs(codeup): add evidence ledger` is OPEN, CLEAN, unmerged; no checks reported. | Release blocker | Merge stacked branch after #83, or rerun equivalent checks on the final release branch. |
+| B6 | #89 `feat: localize high-frequency human-readable CLI output` is OPEN, CLEAN, unmerged; no checks reported. | Release blocker | Merge stacked i18n rollout chain after its base branches and rerun tests on final release branch. |
+| B7 | #90 `test(smoke): add JSON IO contract regressions` is OPEN, CLEAN, unmerged; no checks reported. | Release blocker | Merge after #85 and rerun `npm test` plus smoke contract checks on final release branch. |
+| B8 | #91 `docs(bmad): add v1.2.0 handoff index tracking` is OPEN, CLEAN, unmerged; no checks reported. | Release blocker | Merge after #86 so handoff index and execution tracker are available to release reviewers. |
+| B9 | #92 `docs(i18n): clarify v1.2.0 localization boundaries` is OPEN, CLEAN, unmerged; no checks reported. | Release blocker | Merge after #89 so README/SKILL machine-contract and i18n boundary statements are present. |
+| B10 | Release note for v1.2.0 is not present on this evidence baseline. | Release blocker | Draft final release note after merged PR set is frozen; link commits, PRs, known limitations, and upgrade notes. |
+| B11 | `npm pack --dry-run` was not accepted as final evidence because the release version/tag are absent and prerequisite files are not merged. | Release blocker | Run `npm pack --dry-run` on the final v1.2.0 release branch and record package contents. |
+
+No prerequisite PR listed above is treated as non-blocking while it remains unmerged.
+
+## Non-blocking Residual Risks
+
+These items do not override the `NO-GO` decision. They become candidate residual risks only after all release blockers are cleared.
+
+| ID | Risk | Classification | Mitigation / owner |
+| --- | --- | --- | --- |
+| R1 | GitHub reports no checks on stacked PRs #86/#89/#90/#91/#92 because their bases are story branches rather than `master`. | Non-blocking residual risk after merge | Re-run `npm test`, `npm run lint`, `npm run smoke`, and any live/manual smoke on the final merged release branch. |
+| R2 | Live CLI smoke needs real `YUNXIAO_SMOKE_PAT`, `YUNXIAO_SMOKE_ORG_ID`, and `YUNXIAO_SMOKE_PROJECT_ID`; this environment may not contain production-like credentials. | Non-blocking residual risk after CI-safe gates pass | Release owner runs live smoke in an authorized environment and appends output to the final checklist. |
+| R3 | v1.2.0 intentionally does not localize every CLI command. | Non-blocking residual risk | README/SKILL boundary from #92 must remain visible; defer full CLI localization to post-v1.2.0 backlog. |
+| R4 | Codeup API expansion remains evidence-led and not fully implemented in v1.2.0. | Non-blocking residual risk | Use #86 evidence ledger for v1.3.0 planning; do not advertise unsupported Codeup commands in release notes. |
+
+## Post-release Follow-ups
+
+| Follow-up | Timing | Owner |
+| --- | --- | --- |
+| Full CLI localization beyond `auth`, `whoami`, `project list`, `wi list/view/update`, and `sprint list/view`. | Post-v1.2.0 | Product / Developer |
+| Codeup MR merge/comment/approval/diff/commits/discussions expansion. | v1.3.0 candidate | Product / Architect / Developer |
+| Direct BMAD agent instruction edits outside repo-local workflows/artifacts. | Post-v1.2.0 governance decision | BMAD Master / Governance |
+| Future shell completion and interactive TUI mode. | Post-MVP | Product |
+
+## Verification Evidence
+
+| Check | Status on this evidence branch | Evidence / command |
+| --- | --- | --- |
+| Focused release evidence guardrail | Passed: 4 tests, 0 failures | `node --test test/v1-2-0-release-evidence-summary.test.js` |
+| Full unit suite | Passed: 299 tests, 0 failures | `npm test` after `npm ci` |
+| Dependency install for verification | Completed; npm audit reported 2 existing moderate findings | `npm ci` |
+| Lint / version smoke | Passed and printed `1.1.0` | `npm run lint` currently maps to `node src/index.js --version` |
+| CLI smoke matrix | Blocked on unmerged PR #85 | `npm run smoke` does not exist on this evidence baseline. |
+| Live CLI smoke | Blocked on #85 and live env | `npm run smoke:live` is unavailable until smoke runner is merged. |
+| JSON stdout/stderr/error-code contract regression | Blocked on unmerged PR #90 | Dependency branch evidence exists, but final release branch must rerun after merge. |
+| Release checklist execution | Blocked on unmerged PR #84 | Checklist template is not available on this evidence baseline. |
+| npm pack dry-run | Blocked as final release proof | `npm pack --dry-run` must run after v1.2.0 version/tag branch is ready. |
+
+## Version, Tag, and Package Evidence
+
+| Item | Current evidence | Gate result |
+| --- | --- | --- |
+| `package.json version` | `1.1.0` | Blocker for v1.2.0 |
+| `runtime version` | CLI runtime reads `package.json` via `getPackageVersion()` and therefore currently reports `1.1.0`. | Blocker for v1.2.0 |
+| Latest `git tag` | `v1.1.0`; no `v1.2.0` tag exists. | Blocker |
+| Package files whitelist | `package.json` currently includes `src/` and `README.md`. | Must be rechecked with `npm pack --dry-run` after release branch is final. |
+| `npm pack --dry-run` | Not final-run for v1.2.0 because version/tag and prerequisites are absent. | Blocker |
+
+## Release Note and Publish Workflow Evidence
+
+| Item | Current evidence | Gate result |
+| --- | --- | --- |
+| Release note | No final v1.2.0 release note exists on this evidence baseline. | Blocker |
+| Publish workflow | Existing publish flow is tag-driven; final release must not push `v1.2.0` until blockers are cleared. | Blocker until final GO |
+| Release checklist | Provided by PR #84, currently unmerged. | Blocker |
+| Known limitations | Must include partial CLI localization and deferred Codeup expansion. | Required before GO |
+
+## PR and Commit Traceability
+
+| PR | Scope | Base | Head | Merge / CI evidence | Release gate classification |
+| --- | --- | --- | --- | --- | --- |
+| #83 | Story 13.1 artifact sync rules | `master` | `story/13-1-story-artifact-sync-rules` | OPEN, CLEAN, Node 18/20/22 checks pass, not merged | Release blocker |
+| #84 | Story 12.3 release checklist template | `master` | `story/12-3-release-checklist-template` | OPEN, CLEAN, Node 18/20/22 checks pass, not merged | Release blocker |
+| #85 | Story 12.1 real CLI smoke matrix | `master` | `story/12-1-real-cli-smoke-matrix` | OPEN, CLEAN, Node 18/20/22 checks pass, not merged | Release blocker |
+| #86 | Story 13.2 Codeup evidence ledger | `story/13-1-story-artifact-sync-rules` | `story/13-2-codeup-evidence-ledger` | OPEN, CLEAN, no checks reported, not merged | Release blocker |
+| #89 | Story 11.2 high-frequency zh rollout | `story/11-1-i18n-audit-rollout-scope` | `story/11-2-high-frequency-output-zh-rollout` | OPEN, CLEAN, no checks reported, not merged | Release blocker |
+| #90 | Story 12.2 JSON IO contract regressions | `story/12-1-real-cli-smoke-matrix` | `story/12-2-json-io-contract-regression-tests` | OPEN, CLEAN, no checks reported, not merged | Release blocker |
+| #91 | Story 13.3 handoff index tracking | `story/13-2-codeup-evidence-ledger` | `story/13-3-v1-2-0-handoff-index-tracking-artifacts` | OPEN, CLEAN, no checks reported, not merged | Release blocker |
+| #92 | Story 11.3 README/SKILL i18n boundaries | `story/11-2-high-frequency-output-zh-rollout` | `story/11-3-readme-skill-boundary-clarifications` | OPEN, CLEAN, no checks reported, not merged | Release blocker |
+
+Commit traceability:
+
+- Evidence input baseline HEAD `89d60a8` contains v1.2.0 planning artifacts and workflow templates.
+- `origin/master` HEAD `dcc353a` is tagged `v1.1.0`.
+- v1.2.0 release commit traceability is incomplete until all selected PRs are merged into the final release branch and release notes link the merged PR set.
+
+## Story Evidence Inputs
+
+| Story | Evidence source | Current release-gate status |
+| --- | --- | --- |
+| 11.2 | PR #89 / `_bmad-output/implementation-artifacts/11-2-high-frequency-i18n-rollout.md` | Blocked until merged and tested on final branch. |
+| 11.3 | PR #92 / `_bmad-output/implementation-artifacts/11-3-readme-skill-i18n-boundaries.md` | Blocked until merged after #89. |
+| 12.1 | PR #85 / smoke runner and `test/smoke.test.js` | Blocked until merged; CI checks pass on PR branch. |
+| 12.2 | PR #90 / JSON contract regression evidence | Blocked until merged after #85. |
+| 12.3 | PR #84 / release checklist template | Blocked until merged; CI checks pass on PR branch. |
+| 13.1 | PR #83 / story artifact sync rules | Blocked until merged; CI checks pass on PR branch. |
+| 13.2 | PR #86 / Codeup evidence ledger | Blocked until merged after #83. |
+| 13.3 | PR #91 / handoff index and execution tracker | Blocked until merged after #86. |
+
+## Reviewer Handoff
+
+Reviewer / Scrum Master should not approve v1.2.0 release from this evidence snapshot.
+
+To move from `NO-GO` to candidate `GO`:
+
+1. Merge or explicitly descope every blocker PR with reviewer approval.
+2. Update final release branch to `1.2.0` and verify runtime version, `package.json version`, and `v1.2.0` tag alignment.
+3. Run final branch verification: `npm test`, `npm run lint`, `npm run smoke`, authorized live smoke if credentials exist, and `npm pack --dry-run`.
+4. Complete the release checklist from PR #84 on the final branch.
+5. Draft release note with merged PR list, commit traceability, known limitations, and post-release follow-ups.
+6. Regenerate this evidence summary with final command outputs and reclassify any remaining residual risks.

--- a/test/v1-2-0-release-evidence-summary.test.js
+++ b/test/v1-2-0-release-evidence-summary.test.js
@@ -1,0 +1,75 @@
+import { readFileSync } from "node:fs";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const evidence = readFileSync(
+  new URL("../_bmad-output/implementation-artifacts/v1-2-0-release-evidence-summary.md", import.meta.url),
+  "utf8",
+);
+
+test("release evidence preserves GO/NO-GO decision and required gate sections", () => {
+  const requiredSections = [
+    "## GO/NO-GO Decision",
+    "## Release Blockers",
+    "## Non-blocking Residual Risks",
+    "## Post-release Follow-ups",
+    "## Verification Evidence",
+    "## Version, Tag, and Package Evidence",
+    "## Release Note and Publish Workflow Evidence",
+    "## PR and Commit Traceability",
+    "## Reviewer Handoff",
+  ];
+
+  for (const section of requiredSections) {
+    assert.match(evidence, new RegExp(section.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+
+  assert.match(evidence, /\*\*Decision\*\*: `NO-GO`/);
+  assert.match(evidence, /Open release blockers exist/);
+});
+
+test("unmerged prerequisite PRs are explicitly classified as release blockers", () => {
+  const blockingPrs = [
+    "#83",
+    "#84",
+    "#85",
+    "#86",
+    "#89",
+    "#90",
+    "#91",
+    "#92",
+  ];
+
+  for (const pr of blockingPrs) {
+    assert.match(evidence, new RegExp(`\\| ${pr} \\|[^\\n]+\\| Release blocker \\|`));
+  }
+
+  assert.match(evidence, /No prerequisite PR listed above is treated as non-blocking while it remains unmerged/);
+});
+
+test("release evidence covers tests, smoke, pack dry-run, version, tag, release note, and traceability", () => {
+  const requiredMarkers = [
+    "npm test",
+    "node --test test/v1-2-0-release-evidence-summary.test.js",
+    "npm run smoke",
+    "npm pack --dry-run",
+    "package.json version",
+    "runtime version",
+    "git tag",
+    "v1.2.0",
+    "release note",
+    "publish workflow",
+    "commit traceability",
+    "HEAD `89d60a8`",
+  ];
+
+  for (const marker of requiredMarkers) {
+    assert.match(evidence, new RegExp(marker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i"));
+  }
+});
+
+test("residual risks are separated from blockers and do not override NO-GO", () => {
+  assert.match(evidence, /\| R1 \|[^\n]+\| Non-blocking residual risk/);
+  assert.match(evidence, /\| B1 \|[^\n]+\| Release blocker/);
+  assert.doesNotMatch(evidence, /\*\*Decision\*\*: `GO`/);
+});


### PR DESCRIPTION
## Summary
- Add Story 12.4 implementation artifact and v1.2.0 release evidence summary.
- Record a single NO-GO release decision with explicit release blockers, residual risks, post-release follow-ups, verification evidence, version/tag/package evidence, release note/publish workflow evidence, and PR/commit traceability.
- Add a guardrail test that prevents prerequisite PRs from being treated as non-blocking while unmerged and preserves the GO/NO-GO evidence structure.
- Update sprint status for 12-4-release-evidence-summary to done.

## Test plan
- npm ci
- node --test test/v1-2-0-release-evidence-summary.test.js
- npm run lint
- npm test

## Release gate note
This PR intentionally documents v1.2.0 as NO-GO because prerequisite PRs #83, #84, #85, #86, #89, #90, #91, and #92 remain open/unmerged, package/runtime version is still 1.1.0, no v1.2.0 tag exists, and final release note/checklist/pack dry-run evidence is not yet available on a merged release branch.